### PR TITLE
add bin methods to collection classes

### DIFF
--- a/src/py3r/behaviour/summary.py
+++ b/src/py3r/behaviour/summary.py
@@ -289,6 +289,22 @@ class SummaryCollection:
         summary_dict = {obj.handle: obj for obj in summary_list}
         return cls(summary_dict)
 
+    def make_bin(self, startframe, endframe):
+        # returns a new SummaryCollection with binned summaries
+        binned = {
+            k: v.make_bin(startframe, endframe) for k, v in self.summary_dict.items()
+        }
+        return SummaryCollection(binned)
+
+    def make_bins(self, numbins):
+        # returns a list of SummaryCollection, one per bin
+        bins = {
+            k: v.make_bins(numbins) for k, v in self.summary_dict.items()
+        }  # {k: [Summary, ...]}
+        # Transpose: for each bin index, collect {k: Summary}
+        nbins = len(next(iter(bins.values())))
+        return [SummaryCollection({k: bins[k][i] for k in bins}) for i in range(nbins)]
+
     def store(
         self,
         results_dict: dict[str, SummaryResult],
@@ -398,6 +414,25 @@ class MultipleSummaryCollection:
                 )
             )
         return cls(multiple_summary_collection)
+
+    def make_bin(self, startframe, endframe):
+        """returns a new MultipleSummaryCollection with binned summaries"""
+        binned = {
+            k: v.make_bin(startframe, endframe)
+            for k, v in self.dict_of_summary_collections.items()
+        }
+        return MultipleSummaryCollection(binned)
+
+    def make_bins(self, numbins):
+        """returns a list of MultipleSummaryCollection, one per bin"""
+        bins = {
+            k: v.make_bins(numbins) for k, v in self.dict_of_summary_collections.items()
+        }  # {group: [SummaryCollection, ...]}
+        nbins = len(next(iter(bins.values())))
+        return [
+            MultipleSummaryCollection({k: bins[k][i] for k in bins})
+            for i in range(nbins)
+        ]
 
     def bfa(self, column: str, all_states=None, numshuffles: int = 1000):
         from itertools import combinations

--- a/src/py3r/behaviour/util/collection_utils.py
+++ b/src/py3r/behaviour/util/collection_utils.py
@@ -2,14 +2,18 @@ class _Indexer:
     def __init__(self, parent, slicer):
         self.parent = parent
         self.slicer = slicer
+
     def __getitem__(self, idx):
         return self.slicer(idx)
+
 
 class BatchResult(dict):
     def __init__(self, data, parent_collection):
         super().__init__(data)
         self._parent_collection = parent_collection
+
     def plot(self, *args, **kwargs):
-        return self._parent_collection.plot(self, *args, **kwargs) 
+        return self._parent_collection.plot(self, *args, **kwargs)
+
     def store(self, *args, **kwargs):
         return self._parent_collection.store(self, *args, **kwargs)


### PR DESCRIPTION
Added make_bin() and make_bins() to the MultipleSummaryCollection class to allow for binning of whole collections
make_bin() returns a MutlipleSummaryCollection object, while make_bins() returns a list of MultipleSummaryCollection objects (one for each bin) 