### PR TITLE
Changing type int to Int64 to deal with Nan entries in features

### DIFF
--- a/docs/examples/epm_pipeline.md
+++ b/docs/examples/epm_pipeline.md
@@ -63,7 +63,7 @@ on_oa2 = fc.within_boundary_static(point="bodycentre", boundary=_oa_boundary)
 on_oa = on_oa1 | on_oa2
 on_oa.store(name="bodycentre_on_open_arms")
 
-dist_change_on_oa = on_oa.astype(int) * fc.distance_change("bodycentre")
+dist_change_on_oa = on_oa.astype("Int64") * fc.distance_change("bodycentre")
 dist_change_on_oa.store(name="dist_change_bodycentre_on_oa")
 
 # Closed arms
@@ -75,7 +75,7 @@ on_ca2 = fc.within_boundary_static(point="bodycentre", boundary=_ca_boundary)
 on_ca = on_ca1 | on_ca2
 on_oa.store(name="bodycentre_on_closed_arms")
 
-dist_change_on_ca = on_ca.astype(int) * fc.distance_change("bodycentre")
+dist_change_on_ca = on_ca.astype("Int64") * fc.distance_change("bodycentre")
 dist_change_on_ca.store(name="dist_change_bodycentre_on_ca")
 
 # 7) (Optional) Save features to csv


### PR DESCRIPTION
### Summary
<!-- 
A short description of what this PR does.

Example:
- Adds aggregation functions for multi-animal keypoint trajectories.
-->

- Using Int64 type in EPM pipeline example to handle Nan entries

### Type of change
<!-- 
At least one MUST be checked.
Use lowercase x exactly like this: [x]
-->
- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🧹 Chore / Refactor
- [x] 📚 Docs

### User-facing change
<!-- 
This is what will appear in the release notes.
Write as a single bullet starting with - 

Example:
- Fixed incorrect body-angle computation when animals rotate >180°.
-->

- Using Int64 type in EPM pipeline example to handle Nan entries

### Testing
<!-- 
Explain how you tested the change.

Example:
- Added docstring tests covering interpolation of missing keypoints.
-->

- Run pipeline on some example files
