### PR TITLE
Fix indexing error of pd.series in series_utils.py

### DIFF
--- a/src/py3r/behaviour/util/series_utils.py
+++ b/src/py3r/behaviour/util/series_utils.py
@@ -101,7 +101,10 @@ def remove_block(s1: pd.Series, s2: pd.Series) -> pd.Series:
             if start > 0:
                 replacement_value = s1.iloc[start - 1]
             else:
-                replacement_value = s1.iloc[end + 1]
+                try:
+                    replacement_value = s1.iloc[end]
+                except IndexError:
+                    raise IndexError(f"Index {end} out of range for pandas series s1")
             s1[start:end] = replacement_value
 
     # Step 3: Assign back to DataFrame


### PR DESCRIPTION
### Summary
<!-- 
A short description of what this PR does.

Example:
- Adds aggregation functions for multi-animal keypoint trajectories.
-->
- Fixing indexing error in remove_block() function (series_utils.py)

### Type of change
<!-- 
At least one MUST be checked.
Use lowercase x exactly like this: [x]
-->
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🧹 Chore / Refactor
- [ ] 📚 Docs

### User-facing change
<!-- 
This is what will appear in the release notes.
Write as a single bullet starting with - 

Example:
- Fixed incorrect body-angle computation when animals rotate >180°.
-->

- Fixed error thrown by remove_block() when dealing with pandas series

### Testing
<!-- 
Explain how you tested the change.

Example:
- Added docstring tests covering interpolation of missing keypoints.
-->

- Tested with behavior analysis pipeline