### PR TITLE
rescale distance by distance between medians

### DIFF
--- a/src/py3r/behaviour/tracking/tracking.py
+++ b/src/py3r/behaviour/tracking/tracking.py
@@ -710,7 +710,25 @@ class Tracking:
                     "distance already rescaled. re-load the raw data to change scaling"
                 )
 
-        tracking_distance = self.distance_between(point1, point2, dims=dims).median()
+        tracking_distance = np.sqrt(
+            sum(
+                [
+                    (
+                        self.data[point1 + "." + dim].median()
+                        - self.data[point2 + "." + dim].median()
+                    )
+                    ** 2
+                    for dim in dims
+                ]
+            )
+        )
+        if tracking_distance == 0:
+            raise Exception(f"observed distance between '{point1}' and '{point2}' is 0")
+        if np.isnan(tracking_distance):
+            raise Exception(
+                f"observed distance between '{point1}' and '{point2}' is NaN"
+            )
+
         rescale_factor = distance_in_metres / tracking_distance
 
         tracked_points = self.get_point_names()


### PR DESCRIPTION
### Summary
<!-- 
A short description of what this PR does.

Example:
- Adds aggregation functions for multi-animal keypoint trajectories.
-->
- rescale_distance_scalar calculates distance between medians and includes nan and 0 tolerance

### Type of change
<!-- 
At least one MUST be checked.
Use lowercase x exactly like this: [x]
-->
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🧹 Chore / Refactor
- [ ] 📚 Docs

### User-facing change
<!-- 
This is what will appear in the release notes.
Write as a single bullet starting with - 

Example:
- Fixed incorrect body-angle computation when animals rotate >180°.
-->
- improved nan tolerance in distance calibration

### Testing
<!-- 
Explain how you tested the change.

Example:
- Added docstring tests covering interpolation of missing keypoints.
-->
- manual and docstring tests
