### PR TITLE
Docs/add interpolation pipelines

### DIFF
--- a/docs/examples/epm_pipeline.md
+++ b/docs/examples/epm_pipeline.md
@@ -4,9 +4,9 @@ End‑to‑end example computing various measures for different maze arms using 
 # Load a dataset of single‑view DLC CSVs into a TrackingCollection
 import py3r.behaviour as p3b
 
-DATA_DIR = "/data/recordings"            # e.g. contains EPM_id1.csv, EPM_id2.csv, ...
-TAGS_CSV = "/data/tags.csv"              # optional, with columns: handle, treatment, genotype, ...
-OUT_DIR  = "/outputs"                    # where to save summary outputs
+DATA_DIR = "/data/recordings"  # e.g. contains EPM_id1.csv, EPM_id2.csv, ...
+TAGS_CSV = "/data/tags.csv"  # optional, with columns: handle, treatment, genotype, ...
+OUT_DIR = "/outputs"  # where to save summary outputs
 
 tc = p3b.TrackingCollection.from_dlc_folder(folder_path=DATA_DIR, fps=30)
 
@@ -22,7 +22,7 @@ try:
 except FileNotFoundError:
     pass
 
-# Remove low-confidence detections (method/thresholds depend on your DLC export)
+# Remove low-confidence detections (thresholds depend on your tracking software/data)
 tc.filter_likelihood(threshold=0.5)
 
 # Interpolate missing points before smoothing
@@ -35,31 +35,52 @@ tc.smooth_all(window=3, method="mean")
 tc.rescale_by_known_distance(point1="tl", point2="br", distance_in_metres=0.655)
 
 # Trim ends of recordings if needed
-tc.trim(endframe=-10*30)  # drop 10s from end at 30 fps
+tc.trim(endframe=-10 * 30)  # drop 10s from end at 30 fps
 
 # 4) Basic QA such as checking length of recordings and ploting tracking trajectories
 # Length check (per recording, assuming 5 min, time in seconds)
-timecheck = tc.time_as_expected(mintime=300-(0.1*300) ,maxtime=300+(0.1*300))
+timecheck = tc.time_as_expected(mintime=300 - (0.1 * 300), maxtime=300 + (0.1 * 300))
 for key, val in timecheck.items():
     if not val:
         raise Exception(f"file {key} failed timecheck")
 
 # Plot trajectories (per recording, using 'bodycentre' for trajectory of mouse and corners of EPM as static frame)
-tc.plot(trajectories=["bodycentre"], static=environment_points, 
-        lines=[("tl", "tr"), ("tr", "ctr"), ("ctr", "rt"), ("rt", "rb"),
-               ("rb", "cbr"), ("cbr", "br"), ("br", "bl"), ("bl", "cbl"),
-               ("cbl", "lb"), ("lb", "lt"), ("lt", "ctl"), ("ctl", "tl")])
+# (note that point names will likely be different)
+tc.plot(
+    trajectories=["bodycentre"],
+    static=["tl", "tr", "ctr", "rt", "rb", "cbr", "br", "bl", "cbl", "lb", "lt", "ctl"],
+    lines=[
+        ("tl", "tr"),
+        ("tr", "ctr"),
+        ("ctr", "rt"),
+        ("rt", "rb"),
+        ("rb", "cbr"),
+        ("cbr", "br"),
+        ("br", "bl"),
+        ("bl", "cbl"),
+        ("cbl", "lb"),
+        ("lb", "lt"),
+        ("lt", "ctl"),
+        ("ctl", "tl"),
+    ],
+    show=False,
+    savedir=OUT_DIR,
+)
 
 # 5) Create FeaturesCollection object
 fc = p3b.FeaturesCollection.from_tracking_collection(tc)
 
-# 6) Compute features necessary to get different EPM measures 
+# 6) Compute features necessary to get different EPM measures
 # Define different boundaries (open arms, closed arms) and check if mouse (defined by 'bodycentre') is inside defined boundary
 # Adjust boundaries so they match orientation of your EPM.
 # Open arms
-_oa_boundary = fc.define_boundary(['tl', 'tr', 'ctr', 'ctl'], scaling=1.1, centre = ["ctr", "ctl"])
+_oa_boundary = fc.define_boundary(
+    ["tl", "tr", "ctr", "ctl"], scaling=1.1, centre=["ctr", "ctl"]
+)
 on_oa1 = fc.within_boundary_static(point="bodycentre", boundary=_oa_boundary)
-_oa_boundary = fc.define_boundary(['cbl', 'cbr', 'br', 'bl'], scaling=1.1, centre = ["cbr", "cbl"])
+_oa_boundary = fc.define_boundary(
+    ["cbl", "cbr", "br", "bl"], scaling=1.1, centre=["cbr", "cbl"]
+)
 on_oa2 = fc.within_boundary_static(point="bodycentre", boundary=_oa_boundary)
 on_oa = on_oa1 | on_oa2
 on_oa.store(name="bodycentre_on_open_arms")
@@ -68,9 +89,13 @@ dist_change_on_oa = on_oa.astype("Int64") * fc.distance_change("bodycentre")
 dist_change_on_oa.store(name="dist_change_bodycentre_on_oa")
 
 # Closed arms
-_ca_boundary = fc.define_boundary(["ctr", "rt", "rb", "cbr"], scaling=1.1, centre = ["ctr", "cbr"])
+_ca_boundary = fc.define_boundary(
+    ["ctr", "rt", "rb", "cbr"], scaling=1.1, centre=["ctr", "cbr"]
+)
 on_ca1 = fc.within_boundary_static(point="bodycentre", boundary=_ca_boundary)
-_ca_boundary = fc.define_boundary(["lt", "ctl", "cbl", "lb"], scaling=1.1, centre = ["ctl", "cbl"])
+_ca_boundary = fc.define_boundary(
+    ["lt", "ctl", "cbl", "lb"], scaling=1.1, centre=["ctl", "cbl"]
+)
 on_ca2 = fc.within_boundary_static(point="bodycentre", boundary=_ca_boundary)
 # you can apply binary operators to BatchResult objects
 on_ca = on_ca1 | on_ca2
@@ -99,7 +124,9 @@ sc.sum_column("dist_change_bodycentre_on_oa").store(name="distance_moved_on_open
 sc.time_true("bodycentre_on_closed_arms").store("time_on_closed_arms")
 
 # Distance moved on closed arms
-sc.sum_column("dist_change_bodycentre_on_ca").store(name="distance_moved_on_closed_arms")
+sc.sum_column("dist_change_bodycentre_on_ca").store(
+    name="distance_moved_on_closed_arms"
+)
 
 # 10) Collate scalar outputs into DataFrame and save results in CSV
 summary_df = sc.to_df(include_tags=True)

--- a/docs/examples/grimace_pipeline_behaviourflow.md
+++ b/docs/examples/grimace_pipeline_behaviourflow.md
@@ -26,13 +26,15 @@ try:
 except FileNotFoundError:
     pass
 
-# 3) Batch preprocessing of tracking files
 # Remove low-confidence detections (method/thresholds depend on your DLC export)
-tc.filter_likelihood(threshold=0.6)
+tc.filter_likelihood(threshold=0.5)
 
-# Smooth all points with mean centre window 3, with exception for environment points
+# interpolate before smoothing
+tc.interpolate(limit=5)
+
+# Smooth all points with mean centre window 3
 tc.smooth_all(
-    window=3, method="mean", overrides=[(["tr", "tl", "bl", "br"], "median", 30)]
+    window=3, method="mean"
 )
 
 # Rescale distance to metres according to corners of the GrimACE arena, here named 'tl' and 'br'
@@ -53,6 +55,8 @@ tc.plot(
     trajectories=["bodycentre"],
     static=["tr", "tl", "bl", "br"],
     lines=[("tr", "tl"), ("tl", "bl"), ("bl", "br"), ("br", "tr")],
+    show=False,
+    savedir=OUT_DIR,
 )
 
 # Create FeaturesCollection object
@@ -153,5 +157,19 @@ bfa_stats = sc_grouped.bfa_stats(bfa_results)
 # Save the BehaviourFlow analysis statistics
 with open(f"{OUT_DIR}/bfa_stats.json", "w") as f:
     json.dump(bfa_stats, f, indent=4)
+
+# Plot a chord diagram
+sc.plot_chord(
+    column="km25_standard_norm",
+    all_states=np.arange(0, 25),
+    save_dir=OUT_DIR,
+    show=False,
+    start=-265,
+    end=95,
+    space=5,
+    r_lim=(93, 100),
+    label_kws=dict(r=94, size=12, color="white"),
+    link_kws=dict(ec="black", lw=0.5),
+)
 
 ```

--- a/docs/examples/oft_bfa_pipeline.md
+++ b/docs/examples/oft_bfa_pipeline.md
@@ -27,10 +27,13 @@ except FileNotFoundError:
 
 # 3) Batch preprocessing of tracking files
 # Remove low-confidence detections (method/thresholds depend on your DLC export)
-tc.filter_likelihood(threshold=0.95)
+tc.filter_likelihood(threshold=0.5)
 
-# Smooth all points with mean centre window 3, with exception for environment points
-tc.smooth_all(window=3, method='mean', overrides=[(["tr", "tl", "bl", "br"], "median", 30)])
+# interpolate before smoothing
+tc.interpolate(limit=5)
+
+# Smooth all points with mean centre window 3
+tc.smooth_all(window=3, method='mean', overrides=[(["tr", "tl", "bl", "br"])
 
 # Rescale distance to metres according to corners of the OFT, here named 'tl' and 'br'
 tc.rescale_by_known_distance(point1='tl', point2='br', distance_in_metres=0.64)
@@ -125,6 +128,19 @@ bfa_stats = p3b.SummaryCollection.bfa_stats(bfa_results)
 print(bfa_stats)
 with open(f"{OUT_DIR}/bfa_stats.json", "w") as f:
     json.dump(bfa_stats, f, indent=4)
+
+sc.plot_chord(
+    column="kmeans_25",
+    all_states=np.arange(0, 25),
+    save_dir=OUT_DIR,
+    show=False,
+    start=-265,
+    end=95,
+    space=5,
+    r_lim=(93, 100),
+    label_kws=dict(r=94, size=12, color="white"),
+    link_kws=dict(ec="black", lw=0.5),
+)
 ```
 
 

--- a/docs/examples/oft_pipeline.md
+++ b/docs/examples/oft_pipeline.md
@@ -22,12 +22,15 @@ try:
 except FileNotFoundError:
     pass
 
-# 3) Batch preprocessing of tracking files
+
 # Remove low-confidence detections (method/thresholds depend on your DLC export)
 tc.filter_likelihood(threshold=0.95)
 
+# interpolate before smoothing
+tc.interpolate(limit=5)
+
 # Smooth all points with mean centre window 3, with exception for environment points
-tc.smooth_all(window=3, method='mean', overrides=[(["tr", "tl", "bl", "br"], "median", 30)])
+tc.smooth_all(window=3, method='mean')
 
 # Rescale distance to metres according to corners of the OFT, here named 'tl' and 'br'
 tc.rescale_by_known_distance(point1='tl', point2='br', distance_in_metres=0.64)


### PR DESCRIPTION
### Summary
<!-- 
A short description of what this PR does.

Example:
- Adds aggregation functions for multi-animal keypoint trajectories.
-->
- update pipeline examples to interpolate before smoothing, simplify smoothing, and use updated plotting methods

### Type of change
<!-- 
At least one MUST be checked.
Use lowercase x exactly like this: [x]
-->
- [ ] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🧹 Chore / Refactor
- [x] 📚 Docs

### User-facing change
<!-- 
This is what will appear in the release notes.
Write as a single bullet starting with - 

Example:
- Fixed incorrect body-angle computation when animals rotate >180°.
-->
- simplified/improved pipeline example generality

### Testing
<!-- 
Explain how you tested the change.

Example:
- Added docstring tests covering interpolation of missing keypoints.
-->
- 
