### PR TITLE
add simple cluster embedding wrapper

### DIFF
--- a/src/py3r/behaviour/features/features.py
+++ b/src/py3r/behaviour/features/features.py
@@ -1289,6 +1289,64 @@ class Features:
         embed_df = pd.DataFrame(data, index=self.data.index)
         return embed_df
 
+    def cluster_embedding(
+        self,
+        embedding_dict: dict[str, list[int]],
+        n_clusters: int,
+        random_state: int = 0,
+        *,
+        auto_normalize: bool = False,
+        rescale_factors: dict | None = None,
+        lowmem: bool = False,
+        decimation_factor: int = 10,
+        custom_scaling: dict[str, dict] | None = None,
+        missing_policy: Literal["drop", "impute_weight"] = "drop",
+    ):
+        """
+        Perform k-means clustering on a single Features object.
+
+        Delegates to ``FeaturesCollection.cluster_embedding`` so all
+        clustering logic remains centralised.
+
+        Returns
+        -------
+        (FeaturesResult, centroids DataFrame, normalization_factors or None)
+
+        Examples
+        --------
+        ```pycon
+        >>> import pandas as pd
+        >>> from py3r.behaviour.util.docdata import data_path
+        >>> from py3r.behaviour.tracking.tracking import Tracking
+        >>> from py3r.behaviour.features.features import Features
+        >>> with data_path('py3r.behaviour.tracking._data', 'dlc_single.csv') as p:
+        ...     t = Tracking.from_dlc(str(p), handle='ex', fps=30)
+        >>> f = Features(t)
+        >>> f.store(pd.Series(range(len(t.data)), index=t.data.index), 'counter')
+        >>> result, centroids, norm = f.cluster_embedding({'counter': [0]}, n_clusters=2)
+        >>> isinstance(centroids, pd.DataFrame)
+        True
+        >>> len(result) == len(f.data)
+        True
+
+        ```
+        """
+        from py3r.behaviour.features.features_collection import FeaturesCollection
+
+        fc = FeaturesCollection.from_list([self])
+        batch, centroids, norm = fc.cluster_embedding(
+            embedding_dict,
+            n_clusters,
+            random_state,
+            auto_normalize=auto_normalize,
+            rescale_factors=rescale_factors,
+            lowmem=lowmem,
+            decimation_factor=decimation_factor,
+            custom_scaling=custom_scaling,
+            missing_policy=missing_policy,
+        )
+        return batch[self.handle], centroids, norm
+
     def assign_clusters_by_centroids(
         self,
         embedding: dict[str, list[int]],

--- a/tools/gen_batch_mixins.py
+++ b/tools/gen_batch_mixins.py
@@ -349,6 +349,11 @@ def main() -> None:
     # shadows the plot mixin in the MRO, creating a cycle:
     #   Collection(batch) -> _invoke_batch -> Summary._delegate_plot
     #   -> new Collection(batch) -> _invoke_batch -> ...
+    # cluster_embedding on Features is a thin wrapper that delegates to
+    # FeaturesCollection.cluster_embedding (which uses ClusteringPipeline).
+    # Generating a batch wrapper would shadow the collection-level method.
+    _FEATURES_EXCLUDE = _COMMON_EXCLUDE | frozenset({"cluster_embedding"})
+
     _SUMMARY_EXCLUDE = _COMMON_EXCLUDE | frozenset(
         {
             "snsstrip",
@@ -375,7 +380,7 @@ def main() -> None:
             "Features",
             root / "features" / "features_collection_batch_mixin.py",
             "FeaturesCollectionBatchMixin",
-            _COMMON_EXCLUDE,
+            _FEATURES_EXCLUDE,
         ),
         (
             root / "summary" / "summary.py",


### PR DESCRIPTION
- excluded from batch mixins

### Summary
<!-- 
A short description of what this PR does.

Example:
- Adds aggregation functions for multi-animal keypoint trajectories.
-->
- allows cluster_embedding on single Features object via delegation to FeaturesCollection

### Type of change
<!-- 
At least one MUST be checked.
Use lowercase x exactly like this: [x]
-->
- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🧹 Chore / Refactor
- [ ] 📚 Docs

### User-facing change
<!-- 
This is what will appear in the release notes.
Write as a single bullet starting with - 

Example:
- Fixed incorrect body-angle computation when animals rotate >180°.
-->
- single Features objects can also be clustered using `cluster_embedding()`

### Testing
<!-- 
Explain how you tested the change.

Example:
- Added docstring tests covering interpolation of missing keypoints.
-->
- manual test and docstrings
