### PR TITLE
Feature/separate hue order sns plots

### DIFF
--- a/src/py3r/behaviour/summary/summary_collection_plot_mixin.py
+++ b/src/py3r/behaviour/summary/summary_collection_plot_mixin.py
@@ -396,7 +396,7 @@ class SummaryCollectionPlotMixin:
     # -------------------------------------------------------------------------
 
     @staticmethod
-    def _build_sns_kwargs(df, ax, palette=None, sorted_groups=None):
+    def _build_sns_kwargs(df, ax, palette=None, sorted_groups=None, y_col="value"):
         """
         Build core seaborn plot kwargs based on data shape.
 
@@ -406,6 +406,13 @@ class SummaryCollectionPlotMixin:
         - **Grouped, multi-component**: ``x=component``, ``hue=_group``,
           ``dodge=True``.  Seaborn packs groups tightly within each component
           position with natural gaps between components.
+
+        Parameters
+        ----------
+        y_col : str
+            Name of the y-value column in *df*.  Defaults to ``"value"``
+            but will be the ylabel string when called from
+            :meth:`prepare_plot`.
 
         Returns
         -------
@@ -420,7 +427,7 @@ class SummaryCollectionPlotMixin:
             return {
                 "data": df,
                 "x": "component",
-                "y": "value",
+                "y": y_col,
                 "hue": "component",
                 "dodge": False,
                 "order": components,
@@ -435,7 +442,7 @@ class SummaryCollectionPlotMixin:
             kwargs = {
                 "data": df,
                 "x": "_group",
-                "y": "value",
+                "y": y_col,
                 "hue": "_group",
                 "dodge": False,
                 "order": groups,
@@ -451,7 +458,7 @@ class SummaryCollectionPlotMixin:
         kwargs = {
             "data": df,
             "x": "component",
-            "y": "value",
+            "y": y_col,
             "hue": "_group",
             "dodge": True,
             "order": components,
@@ -893,6 +900,11 @@ class SummaryCollectionPlotMixin:
         n_components = df["component"].nunique()
         n_groups = df["_group"].nunique() if is_grouped else 1
 
+        # Rename the y-column from generic "value" to the actual label so
+        # seaborn auto-labels the y-axis correctly (e.g. "Time (s)").
+        ylabel = auto_ylabel or "Value"
+        df = df.rename(columns={"value": ylabel})
+
         created_fig = ax is None
         if created_fig:
             figsize = self._auto_figsize(n_components, n_groups, figsize)
@@ -900,14 +912,9 @@ class SummaryCollectionPlotMixin:
         else:
             fig = ax.figure
 
-        plot_kwargs, hide_legend = self._build_sns_kwargs(df, ax, palette, sorted_groups)
-
-        # Rename the y-column from generic "value" to the actual label so
-        # seaborn auto-labels the y-axis correctly (e.g. "Time (s)").
-        ylabel = auto_ylabel or "Value"
-        df = df.rename(columns={"value": ylabel})
-        plot_kwargs["y"] = ylabel
-        plot_kwargs["data"] = df
+        plot_kwargs, hide_legend = self._build_sns_kwargs(
+            df, ax, palette, sorted_groups, y_col=ylabel
+        )
 
         # For single-item collections, prefix auto-filename with the handle
         unique_handles = df["_handle"].unique()

--- a/tests/epm_pipeline/epm_pipeline.py
+++ b/tests/epm_pipeline/epm_pipeline.py
@@ -577,12 +577,12 @@ print(f"EPM grouped snsbar: {len(df_grouped)} rows, groups: {list(df_grouped['_g
 # %%
 # norender
 if TEST_MODE:
-    # Tidy DataFrame structure
-    assert {"component", "value", "_handle"} <= set(df_tidy.columns)
+    # Tidy DataFrame structure (y-column is renamed to the ylabel by prepare_plot)
+    assert {"component", "_handle"} <= set(df_tidy.columns)
     assert len(df_tidy) > 0
 
     # Grouped DataFrame structure
-    assert {"component", "value", "_handle", "_group"} <= set(df_grouped.columns)
+    assert {"component", "_handle", "_group"} <= set(df_grouped.columns)
     assert df_grouped["_group"].nunique() == 3, "Expected 3 treatment groups"
 
     # At least one auto-named plot saved

--- a/tests/oft_pipeline/oft_pipeline.py
+++ b/tests/oft_pipeline/oft_pipeline.py
@@ -673,22 +673,24 @@ fig, ax, df_mc = sc.snsbar(
 # norender
 if TEST_MODE:
     # --- Flat tidy DataFrame structure ---
+    # The y-column is renamed from "value" to the ylabel by prepare_plot,
+    # so we check for the structural columns only.
     for label, df_check in [
         ("strip", df_strip),
         ("bar", df_bar),
         ("super", df_super),
     ]:
-        assert {"component", "value", "_handle"} <= set(df_check.columns), (
+        assert {"component", "_handle"} <= set(df_check.columns), (
             f"{label}: missing required columns"
         )
         assert len(df_check) > 0, f"{label}: empty DataFrame"
 
     # --- Single Summary delegation ---
-    assert {"component", "value", "_handle"} <= set(df_single.columns)
+    assert {"component", "_handle"} <= set(df_single.columns)
 
     # --- Grouped tidy DataFrame structure ---
     for label, df_check in [("gsup", df_gsup), ("gbar", df_gbar)]:
-        assert {"component", "value", "_handle", "_group"} <= set(df_check.columns), (
+        assert {"component", "_handle", "_group"} <= set(df_check.columns), (
             f"{label}: missing required columns"
         )
         assert df_check["_group"].nunique() > 1, f"{label}: expected multiple groups"


### PR DESCRIPTION
### Summary
<!-- 
A short description of what this PR does.

Example:
- Adds aggregation functions for multi-animal keypoint trajectories.
-->
- allows hue order to be set independently of display order in sns wrappers

### Type of change
<!-- 
At least one MUST be checked.
Use lowercase x exactly like this: [x]
-->
- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🧹 Chore / Refactor
- [ ] 📚 Docs

### User-facing change
<!-- 
This is what will appear in the release notes.
Write as a single bullet starting with - 

Example:
- Fixed incorrect body-angle computation when animals rotate >180°.
-->
- allows hue order to be set independently of display order in sns wrappers

### Testing
<!-- 
Explain how you tested the change.

Example:
- Added docstring tests covering interpolation of missing keypoints.
-->
- manual tests
