### PR TITLE
increased scope for binary ops on Batchresult

### DIFF
--- a/src/py3r/behaviour/util/collection_utils.py
+++ b/src/py3r/behaviour/util/collection_utils.py
@@ -185,6 +185,48 @@ class BatchResult(dict):
 
         return self._binary_op(other, operator.truediv)
 
+    # Reflected arithmetic operators
+    def __radd__(self, other):
+        import operator
+
+        return self._binary_op(other, lambda a, b: operator.add(b, a))
+
+    def __rsub__(self, other):
+        import operator
+
+        return self._binary_op(other, lambda a, b: operator.sub(b, a))
+
+    def __rmul__(self, other):
+        import operator
+
+        return self._binary_op(other, lambda a, b: operator.mul(b, a))
+
+    def __rtruediv__(self, other):
+        import operator
+
+        return self._binary_op(other, lambda a, b: operator.truediv(b, a))
+
+    # Comparisons
+    def __lt__(self, other):
+        import operator
+
+        return self._binary_op(other, operator.lt)
+
+    def __le__(self, other):
+        import operator
+
+        return self._binary_op(other, operator.le)
+
+    def __gt__(self, other):
+        import operator
+
+        return self._binary_op(other, operator.gt)
+
+    def __ge__(self, other):
+        import operator
+
+        return self._binary_op(other, operator.ge)
+
     # Logical operators (expect boolean leaves)
     def __or__(self, other):
         import operator
@@ -200,6 +242,22 @@ class BatchResult(dict):
         import operator
 
         return self._binary_op(other, operator.xor)
+
+    # Reflected logical operators (for scalar bool on the left)
+    def __ror__(self, other):
+        import operator
+
+        return self._binary_op(other, lambda a, b: operator.or_(b, a))
+
+    def __rand__(self, other):
+        import operator
+
+        return self._binary_op(other, lambda a, b: operator.and_(b, a))
+
+    def __rxor__(self, other):
+        import operator
+
+        return self._binary_op(other, lambda a, b: operator.xor(b, a))
 
     def __invert__(self):
         """

--- a/tests/test_each_batch_modes.py
+++ b/tests/test_each_batch_modes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pandas as pd
 import pytest
 
 from py3r.behaviour.exceptions import BatchProcessError
@@ -138,3 +139,51 @@ def test_each_invalid_batchresult_mapping_raises():
     bad = BatchResult({"A": "left"}, coll)  # missing B
     with pytest.raises(BatchProcessError, match="BatchResult mapping keys"):
         coll.each.label(bad)
+
+
+def test_batchresult_scalar_arithmetic_and_comparison():
+    coll = _make_collection()
+    out = BatchResult(
+        {
+            "A": pd.Series([0.2, 0.7]),
+            "B": pd.Series([1.0, -1.0]),
+        },
+        coll,
+    )
+
+    plus = out + 3.0
+    gt = out > 0.5
+
+    assert plus["A"].tolist() == [3.2, 3.7]
+    assert plus["B"].tolist() == [4.0, 2.0]
+    assert gt["A"].tolist() == [False, True]
+    assert gt["B"].tolist() == [True, False]
+
+
+def test_batchresult_reflected_scalar_arithmetic_and_logical():
+    coll = _make_collection()
+    numeric = BatchResult(
+        {
+            "A": pd.Series([0.2, 0.7]),
+            "B": pd.Series([1.0, -1.0]),
+        },
+        coll,
+    )
+    mask = BatchResult(
+        {
+            "A": pd.Series([True, False]),
+            "B": pd.Series([False, True]),
+        },
+        coll,
+    )
+
+    left_add = 3.0 + numeric
+    left_sub = 3.0 - numeric
+    left_and = True & mask
+
+    assert left_add["A"].tolist() == [3.2, 3.7]
+    assert left_add["B"].tolist() == [4.0, 2.0]
+    assert left_sub["A"].tolist() == [2.8, 2.3]
+    assert left_sub["B"].tolist() == [2.0, 4.0]
+    assert left_and["A"].tolist() == [True, False]
+    assert left_and["B"].tolist() == [False, True]


### PR DESCRIPTION
### Summary
<!-- 
A short description of what this PR does.

Example:
- Adds aggregation functions for multi-animal keypoint trajectories.
-->
- more binary operations on BatchResult objects

### Type of change
<!-- 
At least one MUST be checked.
Use lowercase x exactly like this: [x]
-->
- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🧹 Chore / Refactor
- [ ] 📚 Docs

### User-facing change
<!-- 
This is what will appear in the release notes.
Write as a single bullet starting with - 

Example:
- Fixed incorrect body-angle computation when animals rotate >180°.
-->
- more binary operations on BatchResult objects

### Testing
<!-- 
Explain how you tested the change.

Example:
- Added docstring tests covering interpolation of missing keypoints.
-->
- docstring tests and additional test modules
