### PR TITLE
add all_states option

### DIFF
--- a/src/py3r/behaviour/summary/summary.py
+++ b/src/py3r/behaviour/summary/summary.py
@@ -824,7 +824,7 @@ class Summary:
         ['B', 'C', 'A']
         >>> res = s.count_state_onsets('state', all_states=['A'])
         >>> res.value.tolist()
-        [1]
+        [2]
         >>> res.value.index.tolist()
         ['A']
         >>> hasattr(res, 'value')

--- a/src/py3r/behaviour/summary/summary.py
+++ b/src/py3r/behaviour/summary/summary.py
@@ -789,9 +789,18 @@ class Summary:
         }
         return SummaryResult(transition_matrix, self, f"transition_matrix_{column}", meta)
 
-    def count_state_onsets(self, column: str) -> SummaryResult:
+    def count_state_onsets(self, column: str, all_states: list | None = None) -> SummaryResult:
         """
         counts the number of times a state is entered in a given column
+
+        Parameters
+        ----------
+        column:
+            Name of the state column in ``features.data``.
+        all_states:
+            Optional explicit state ordering to control index presence/order in the
+            returned Series. When provided, the output is reindexed to ``all_states``
+            and missing states are filled with ``0``.
         Examples
         --------
         ```pycon
@@ -806,7 +815,18 @@ class Summary:
         >>> states = pd.Series(['A','A','B','B','A'][:len(t.data)], index=t.data.index)
         >>> f.store(states, 'state', meta={})
         >>> s = Summary(f)
-        >>> res = s.count_state_onsets('state')
+        >>> res = s.count_state_onsets('state', all_states=['B', 'C', 'A'])
+        >>> res.value.index.tolist()
+        ['B', 'C', 'A']
+        >>> res.value.tolist()
+        [1, 0, 1]
+        >>> res._params['all_states']
+        ['B', 'C', 'A']
+        >>> res = s.count_state_onsets('state', all_states=['A'])
+        >>> res.value.tolist()
+        [1]
+        >>> res.value.index.tolist()
+        ['A']
         >>> hasattr(res, 'value')
         True
 
@@ -818,14 +838,25 @@ class Summary:
         transitions = states != states.shift()
         transition_states = states[transitions]
         state_counts = transition_states.value_counts()
-        meta = {"function": "count_state_onsets", "column": column}
+        if all_states is not None:
+            state_counts = state_counts.reindex(all_states, fill_value=0)
+        meta = {"function": "count_state_onsets", "column": column, "all_states": all_states}
         return SummaryResult(
             state_counts, self, f"count_state_onsets_{column}", meta, ylabel="Count"
         )
 
-    def time_in_state(self, column: str) -> SummaryResult:
+    def time_in_state(self, column: str, all_states: list | None = None) -> SummaryResult:
         """
         returns the time spent in each state in a given column
+
+        Parameters
+        ----------
+        column:
+            Name of the state column in ``features.data``.
+        all_states:
+            Optional explicit state ordering to control index presence/order in the
+            returned Series. When provided, the output is reindexed to ``all_states``
+            and missing states are filled with ``0``.
         Examples
         --------
         ```pycon
@@ -840,7 +871,18 @@ class Summary:
         >>> states = pd.Series(['A','A','B','B','A'][:len(t.data)], index=t.data.index)
         >>> f.store(states, 'state', meta={})
         >>> s = Summary(f)
-        >>> res = s.time_in_state('state')
+        >>> res = s.time_in_state('state', all_states=['B', 'C', 'A'])
+        >>> res.value.index.tolist()
+        ['B', 'C', 'A']
+        >>> [round(v, 4) for v in res.value.tolist()]
+        [0.0667, 0.0, 0.1]
+        >>> res._params['all_states']
+        ['B', 'C', 'A']
+        >>> res = s.time_in_state('state', all_states=['A'])
+        >>> [round(v, 4) for v in res.value.tolist()]
+        [0.1]
+        >>> res.value.index.tolist()
+        ['A']
         >>> hasattr(res, 'value')
         True
 
@@ -850,7 +892,9 @@ class Summary:
             raise ValueError(f"Column '{column}' not found in features.data")
         states = self.features.data[column]
         time_in_state = states.value_counts() / self.features.tracking.meta["fps"]
-        meta = {"function": "time_in_state", "column": column}
+        if all_states is not None:
+            time_in_state = time_in_state.reindex(all_states, fill_value=0)
+        meta = {"function": "time_in_state", "column": column, "all_states": all_states}
         return SummaryResult(
             time_in_state, self, f"time_in_state_{column}", meta, ylabel="Time (s)"
         )

--- a/src/py3r/behaviour/summary/summary.py
+++ b/src/py3r/behaviour/summary/summary.py
@@ -819,7 +819,7 @@ class Summary:
         >>> res.value.index.tolist()
         ['B', 'C', 'A']
         >>> res.value.tolist()
-        [1, 0, 1]
+        [1, 0, 2]
         >>> res._params['all_states']
         ['B', 'C', 'A']
         >>> res = s.count_state_onsets('state', all_states=['A'])

--- a/tests/test_summary_time_in_state.py
+++ b/tests/test_summary_time_in_state.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from py3r.behaviour.features.features import Features
+from py3r.behaviour.summary.summary import Summary
+from py3r.behaviour.tracking.tracking import Tracking
+
+
+def _make_summary_with_states(states: list[str], fps: float = 2.0) -> Summary:
+    n_frames = len(states)
+    tracking_df = pd.DataFrame(
+        {
+            "bp.x": [float(i) for i in range(n_frames)],
+            "bp.y": [0.0 for _ in range(n_frames)],
+        },
+        index=pd.RangeIndex(n_frames, name="frame"),
+    )
+    tracking = Tracking(
+        tracking_df,
+        {"fps": fps, "rescale_distance_method": "dummy"},
+        handle="ex",
+    )
+    features = Features(tracking)
+    features.store(pd.Series(states, index=tracking_df.index, name="state"), "state", meta={})
+    return Summary(features)
+
+
+def test_time_in_state_default_returns_observed_states_only():
+    summary = _make_summary_with_states(["A", "A", "B", "A"], fps=2.0)
+
+    result = summary.time_in_state("state")
+
+    assert set(result.value.index.tolist()) == {"A", "B"}
+    assert result.value["A"] == 1.5  # 3 frames / 2 fps
+    assert result.value["B"] == 0.5  # 1 frame / 2 fps
+
+
+def test_time_in_state_all_states_includes_missing_and_respects_order():
+    summary = _make_summary_with_states(["A", "A", "B", "A"], fps=2.0)
+
+    result = summary.time_in_state("state", all_states=["B", "C", "A"])
+
+    assert result.value.index.tolist() == ["B", "C", "A"]
+    assert result.value["B"] == 0.5
+    assert result.value["C"] == 0.0
+    assert result.value["A"] == 1.5
+    assert result._params["all_states"] == ["B", "C", "A"]
+
+
+def test_time_in_state_all_states_can_exclude_unwanted_states():
+    summary = _make_summary_with_states(["A", "A", "B", "A"], fps=2.0)
+
+    result = summary.time_in_state("state", all_states=["A"])
+
+    assert result.value.index.tolist() == ["A"]
+    assert result.value["A"] == 1.5
+
+
+def test_count_state_onsets_default_returns_observed_states_only():
+    summary = _make_summary_with_states(["A", "A", "B", "A"], fps=2.0)
+
+    result = summary.count_state_onsets("state")
+
+    assert set(result.value.index.tolist()) == {"A", "B"}
+    assert result.value["A"] == 2
+    assert result.value["B"] == 1
+
+
+def test_count_state_onsets_all_states_includes_missing_and_respects_order():
+    summary = _make_summary_with_states(["A", "A", "B", "A"], fps=2.0)
+
+    result = summary.count_state_onsets("state", all_states=["B", "C", "A"])
+
+    assert result.value.index.tolist() == ["B", "C", "A"]
+    assert result.value["B"] == 1
+    assert result.value["C"] == 0
+    assert result.value["A"] == 2
+    assert result._params["all_states"] == ["B", "C", "A"]
+
+
+def test_count_state_onsets_all_states_can_exclude_unwanted_states():
+    summary = _make_summary_with_states(["A", "A", "B", "A"], fps=2.0)
+
+    result = summary.count_state_onsets("state", all_states=["A"])
+
+    assert result.value.index.tolist() == ["A"]
+    assert result.value["A"] == 2


### PR DESCRIPTION
### Summary
<!-- 
A short description of what this PR does.

Example:
- Adds aggregation functions for multi-animal keypoint trajectories.
-->
- specify `all_states` for state-related `Summary` metrics

### Type of change
<!-- 
At least one MUST be checked.
Use lowercase x exactly like this: [x]
-->
- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🧹 Chore / Refactor
- [ ] 📚 Docs

### User-facing change
<!-- 
This is what will appear in the release notes.
Write as a single bullet starting with - 

Example:
- Fixed incorrect body-angle computation when animals rotate >180°.
-->
- specify `all_states` for state-related `Summary` metrics

### Testing
<!-- 
Explain how you tested the change.

Example:
- Added docstring tests covering interpolation of missing keypoints.
-->
- docstring, manual, new tests
