### PR TITLE
compose state from bool via each

### DIFF
--- a/src/py3r/behaviour/features/features.py
+++ b/src/py3r/behaviour/features/features.py
@@ -1530,9 +1530,11 @@ class Features:
         ...     t = Tracking.from_dlc(str(p), handle='ex', fps=30)
         >>> f = Features(t)
         >>> idx = t.data.index
-        >>> f.store(pd.Series([True, False, True, False], index=idx).reindex(idx, fill_value=False),
+        >>> f.store(pd.Series([True, False, True, False, True], index=idx).reindex(idx,
+        ...         fill_value=False),
         ...         'in_corner', meta={})
-        >>> f.store(pd.Series([False, True, True, False], index=idx).reindex(idx, fill_value=False),
+        >>> f.store(pd.Series([False, True, True, False, True], index=idx).reindex(idx,
+        ...         fill_value=False),
         ...         'in_food', meta={})
         >>> state = f.compose_state_from_booleans(
         ...     {"corner": "in_corner", "food": "in_food"},

--- a/src/py3r/behaviour/features/features.py
+++ b/src/py3r/behaviour/features/features.py
@@ -34,6 +34,7 @@ from py3r.behaviour.util.io_utils import (
 from py3r.behaviour.util.missing_tolerance import impute_frame
 from py3r.behaviour.util.series_utils import (
     apply_normalization_to_df,
+    compose_state_from_boolean_sources,
     normalize_df,
 )
 from py3r.behaviour.util.smoothing import smooth_series
@@ -1494,6 +1495,93 @@ class Features:
         name = f"distance_change_{point}_in_{''.join(dims)}"
         meta = {"function": "distance_change", "point": point, "dims": dims}
         return FeaturesResult(result, self, name, meta)
+
+    def compose_state_from_booleans(
+        self,
+        sources: dict[str, str | pd.Series],
+        *,
+        priority: list[str] | None = None,
+        none_label: str = "none",
+    ) -> FeaturesResult:
+        """
+        Compose a categorical state series from labeled boolean sources.
+
+        Parameters
+        ----------
+        sources:
+            Mapping ``{state_label: source}``, where source is either:
+            - a column name in ``self.data`` containing a boolean series, or
+            - a boolean pandas Series aligned/reindexable to ``self.data.index`` (e.g.
+            a ``FeaturesResult``)
+        priority:
+            Optional label precedence when multiple sources are True in the same
+            frame. Labels not listed are appended in insertion order.
+        none_label:
+            Label used when no source is True at a frame.
+
+        Examples
+        --------
+        ```pycon
+        >>> import pandas as pd
+        >>> from py3r.behaviour.util.docdata import data_path
+        >>> from py3r.behaviour.tracking.tracking import Tracking
+        >>> from py3r.behaviour.features.features import Features
+        >>> with data_path('py3r.behaviour.tracking._data', 'dlc_single.csv') as p:
+        ...     t = Tracking.from_dlc(str(p), handle='ex', fps=30)
+        >>> f = Features(t)
+        >>> idx = t.data.index
+        >>> f.store(pd.Series([True, False, True, False], index=idx).reindex(idx, fill_value=False),
+        ...         'in_corner', meta={})
+        >>> f.store(pd.Series([False, True, True, False], index=idx).reindex(idx, fill_value=False),
+        ...         'in_food', meta={})
+        >>> state = f.compose_state_from_booleans(
+        ...     {"corner": "in_corner", "food": "in_food"},
+        ...     priority=["food", "corner"],
+        ... )
+        >>> isinstance(state, pd.Series)
+        True
+        >>> set(state.dropna().unique()) >= {'corner', 'food', 'none'}
+        True
+
+        ```
+        """
+        if not isinstance(sources, dict) or len(sources) == 0:
+            raise ValueError("sources must be a non-empty dict")
+        if none_label in sources.keys():
+            raise ValueError(f"none_label, '{none_label}', found in sources.keys()")
+
+        resolved: dict[str, pd.Series] = {}
+        source_spec = {}
+        for label, source in sources.items():
+            if isinstance(source, str):
+                if source not in self.data.columns:
+                    raise ValueError(f"Column '{source}' not found in features.data")
+                resolved[label] = self.data[source]
+                source_spec[label] = {"type": "column", "name": source}
+            elif isinstance(source, pd.Series):
+                resolved[label] = source
+                source_spec[label] = {"type": "series"}
+            else:
+                raise TypeError(
+                    f"Source '{label}' must be a column name (str) or pandas Series, "
+                    f"got {type(source).__name__}."
+                )
+
+        state = compose_state_from_boolean_sources(
+            resolved,
+            index=self.tracking.data.index,
+            priority=priority,
+            none_label=none_label,
+        )
+        name = "state_from_booleans"
+        meta = {
+            "function": "compose_state_from_booleans",
+            "labels": list(sources.keys()),
+            "priority": priority,
+            "none_label": none_label,
+            "sources": source_spec,
+        }
+        return FeaturesResult(state, self, name, meta)
 
     def store(
         self,

--- a/src/py3r/behaviour/util/base_collection.py
+++ b/src/py3r/behaviour/util/base_collection.py
@@ -198,8 +198,10 @@ class BaseCollection(MutableMapping):
           a warning is emitted and handle-based mapping is used.
         - If a ``BatchResult`` cannot be resolved to one of the above mapping
           shapes, an error is raised.
-        - All non-``BatchResult`` values (including plain ``dict``) are
-          treated as scalar-broadcast values.
+        - Plain ``dict`` values are scalar-broadcast unless at least one value
+          is a ``BatchResult``. In that mixed case, each embedded
+          ``BatchResult`` is mapped per leaf while non-``BatchResult`` entries
+          are broadcast unchanged.
 
         If any leaf raises, a ``BatchProcessError`` is raised immediately.
         On complete success, returns a ``BatchResult`` of leaf return values
@@ -289,6 +291,10 @@ class BaseCollection(MutableMapping):
             return mode, value
 
         def select(spec, group_key, obj_key):
+            if isinstance(spec, Mapping) and not isinstance(spec, BatchResult):
+                has_embedded_batch = any(isinstance(v, BatchResult) for v in spec.values())
+                if has_embedded_batch:
+                    return {k: select(v, group_key, obj_key) for k, v in spec.items()}
             mode, resolved = _resolve_mode(spec)
             if mode == "grouped":
                 return resolved[group_key][obj_key]
@@ -539,11 +545,42 @@ class BaseCollection(MutableMapping):
         uses smart argument handling:
         - exact-key ``BatchResult`` mappings are applied per handle/group-handle
           structure,
-        - all other values (including plain ``dict``) are broadcast as scalars.
+        - plain ``dict`` values are broadcast as scalars unless they contain at
+          least one embedded ``BatchResult`` value; in that mixed case embedded
+          ``BatchResult`` values are mapped per leaf and other dict values are
+          broadcast unchanged.
 
         Returns either:
         - a collection (when all leaf returns are collection element type), or
         - a BatchResult otherwise.
+
+        Examples
+        --------
+        ```pycon
+        >>> import pandas as pd
+        >>> from py3r.behaviour.util.collection_utils import BatchResult
+        >>> from py3r.behaviour.features.features_collection import FeaturesCollection
+        >>> from py3r.behaviour.features.features import Features
+        >>> from py3r.behaviour.tracking.tracking import Tracking
+        >>> def _mk(handle):
+        ...     df = pd.DataFrame({"bp.x":[0.0,1.0], "bp.y":[0.0,1.0]}, index=[0,1])
+        ...     t = Tracking(
+        ...         df,
+        ...         {"fps": 30.0, "rescale_distance_method": "dummy"},
+        ...         handle=handle,
+        ...     )
+        ...     return Features(t)
+        >>> fc = FeaturesCollection({"A": _mk("A"), "B": _mk("B")})
+        >>> food = BatchResult({
+        ...     "A": pd.Series([True, False], index=[0,1]),
+        ...     "B": pd.Series([False, True], index=[0,1]),
+        ... }, fc)
+        >>> corner = pd.Series([False, False], index=[0,1])
+        >>> out = fc.each.compose_state_from_booleans({"food": food, "corner": corner})
+        >>> isinstance(out, BatchResult)
+        True
+
+        ```
         """
         if self._each_proxy is None:
             self._each_proxy = _EachProxy(self)

--- a/src/py3r/behaviour/util/series_utils.py
+++ b/src/py3r/behaviour/util/series_utils.py
@@ -1,8 +1,10 @@
+import warnings
 from math import ceil, floor
 from typing import Literal
 
 import numpy as np
 import pandas as pd
+from pandas.api.types import is_bool_dtype
 
 
 def mode(series: pd.Series):
@@ -443,3 +445,109 @@ def latencies_from_series(
         bool_series = smooth_bool_series(bool_series, integration_window)
 
     return latencies_from_bool(bool_series)
+
+
+def ensure_nullable_boolean(series: pd.Series, *, label: str) -> pd.Series:
+    """
+    Validate/coerce a series to pandas nullable boolean dtype.
+
+    Accepts:
+    - native bool dtype
+    - pandas nullable boolean dtype
+    - object-like series containing only True/False/NA values
+
+    Examples
+    --------
+    ```pycon
+    >>> import pandas as pd
+    >>> s = pd.Series([True, False, None], dtype="object")
+    >>> out = ensure_nullable_boolean(s, label="zone")
+    >>> str(out.dtype)
+    'boolean'
+    >>> out.tolist()
+    [True, False, <NA>]
+
+    ```
+    """
+    if is_bool_dtype(series):
+        return series.astype("boolean")
+
+    non_na = series.dropna()
+    # Strict bool-like check to avoid accepting integer 0/1 as booleans.
+    if non_na.map(lambda x: isinstance(x, (bool, np.bool_))).all():
+        warnings.warn(
+            f"Boolean source '{label}' had non-boolean dtype; coercing to nullable boolean.",
+            stacklevel=3,
+        )
+        return series.astype("boolean")
+
+    raise TypeError(
+        f"Source '{label}' must be boolean/nullable-boolean (or contain only True/False/NA). "
+        f"Got dtype '{series.dtype}'."
+    )
+
+
+def compose_state_from_boolean_sources(
+    sources: dict[str, pd.Series],
+    *,
+    index: pd.Index,
+    priority: list[str] | None = None,
+    none_label: str = "none",
+) -> pd.Series:
+    """
+    Compose a single categorical state series from labeled boolean sources.
+
+    State assignment follows ``priority`` order. The first True label wins per frame.
+    Frames with no True label are assigned ``none_label``.
+
+    Examples
+    --------
+    ```pycon
+    >>> import pandas as pd
+    >>> idx = pd.RangeIndex(4, name="frame")
+    >>> sources = {
+    ...     "corner": pd.Series([True, False, True, False], index=idx),
+    ...     "food": pd.Series([False, True, True, False], index=idx),
+    ... }
+    >>> state = compose_state_from_boolean_sources(
+    ...     sources,
+    ...     index=idx,
+    ...     priority=["food", "corner"],
+    ...     none_label="none",
+    ... )
+    >>> state.tolist()
+    ['corner', 'food', 'food', 'none']
+
+    ```
+    """
+    if not isinstance(sources, dict) or len(sources) == 0:
+        raise ValueError("sources must be a non-empty mapping of label -> Series")
+
+    labels = list(sources.keys())
+    if any(not isinstance(lbl, str) or lbl == "" for lbl in labels):
+        raise TypeError("All source labels must be non-empty strings")
+
+    if priority is None:
+        order = labels
+    else:
+        if len(priority) != len(set(priority)):
+            raise ValueError("priority contains duplicate labels")
+        unknown = [lbl for lbl in priority if lbl not in sources]
+        if unknown:
+            raise ValueError(f"priority contains unknown label(s): {unknown}")
+        missing = [lbl for lbl in labels if lbl not in priority]
+        order = list(priority) + missing
+
+    bool_df = pd.DataFrame(index=index)
+    for label, series in sources.items():
+        if not isinstance(series, pd.Series):
+            raise TypeError(f"Source '{label}' must be a pandas Series")
+        aligned = series.reindex(index)
+        bool_df[label] = ensure_nullable_boolean(aligned, label=label)
+
+    state = pd.Series(none_label, index=index, dtype="object")
+    for label in order:
+        mask = bool_df[label].fillna(False)
+        state.loc[(state == none_label) & mask] = label
+
+    return state

--- a/tests/test_compose_state_from_booleans.py
+++ b/tests/test_compose_state_from_booleans.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from py3r.behaviour.exceptions import BatchProcessError
+from py3r.behaviour.features.features import Features
+from py3r.behaviour.features.features_collection import FeaturesCollection
+from py3r.behaviour.tracking.tracking import Tracking
+from py3r.behaviour.util.collection_utils import BatchResult
+
+
+def _make_features(handle: str, n_frames: int = 4) -> Features:
+    tracking_df = pd.DataFrame(
+        {
+            "bp.x": [float(i) for i in range(n_frames)],
+            "bp.y": [0.0 for _ in range(n_frames)],
+        },
+        index=pd.RangeIndex(n_frames, name="frame"),
+    )
+    tracking = Tracking(
+        tracking_df,
+        {"fps": 30.0, "rescale_distance_method": "dummy"},
+        handle=handle,
+    )
+    return Features(tracking)
+
+
+def test_features_compose_state_from_booleans_priority_and_none_label():
+    features = _make_features("A")
+    idx = features.tracking.data.index
+    features.store(pd.Series([True, False, True, False], index=idx), "in_corner")
+    features.store(pd.Series([False, True, True, False], index=idx), "in_food")
+
+    state = features.compose_state_from_booleans(
+        {"corner": "in_corner", "food": "in_food"},
+        priority=["food", "corner"],
+        none_label="none",
+    )
+
+    assert state.tolist() == ["corner", "food", "food", "none"]
+    assert state.name == "state_from_booleans"
+
+
+def test_features_compose_state_from_booleans_coerces_bool_like_object_series():
+    features = _make_features("A", n_frames=3)
+    object_bool = pd.Series([True, False, None], index=features.tracking.data.index, dtype="object")
+
+    with pytest.warns(UserWarning, match="coercing to nullable boolean"):
+        state = features.compose_state_from_booleans({"corner": object_bool})
+
+    assert state.tolist() == ["corner", "none", "none"]
+
+
+def test_features_compose_state_from_booleans_rejects_non_boolean_content():
+    features = _make_features("A", n_frames=3)
+    bad = pd.Series([1, 0, 1], index=features.tracking.data.index, dtype="int64")
+
+    with pytest.raises(TypeError, match="must be boolean/nullable-boolean"):
+        features.compose_state_from_booleans({"corner": bad})
+
+
+def test_features_collection_each_compose_state_from_booleans_with_mixed_dict_mapping():
+    fa = _make_features("A")
+    fb = _make_features("B")
+    fa.store(pd.Series([True, False, False, False], index=fa.tracking.data.index), "in_corner")
+    fb.store(pd.Series([False, True, False, False], index=fb.tracking.data.index), "in_corner")
+
+    fc = FeaturesCollection({"A": fa, "B": fb})
+    in_food = BatchResult(
+        {
+            "A": pd.Series([False, True, False, False], index=fa.tracking.data.index),
+            "B": pd.Series([True, False, False, False], index=fb.tracking.data.index),
+        },
+        fc,
+    )
+
+    states = fc.each.compose_state_from_booleans(
+        {"corner": "in_corner", "food": in_food},
+        priority=["food", "corner"],
+    )
+
+    assert isinstance(states, BatchResult)
+    assert states["A"].tolist() == ["corner", "food", "none", "none"]
+    assert states["B"].tolist() == ["food", "corner", "none", "none"]
+
+
+def test_features_collection_each_compose_state_from_booleans_rejects_key_mismatch():
+    fa = _make_features("A")
+    fb = _make_features("B")
+    fc = FeaturesCollection({"A": fa, "B": fb})
+    bad_source = BatchResult(
+        {"A": pd.Series([True, False, True, False], index=fa.tracking.data.index)},
+        fc,
+    )
+
+    with pytest.raises(BatchProcessError, match="BatchResult mapping keys"):
+        fc.each.compose_state_from_booleans({"corner": bad_source})
+
+
+def test_grouped_collection_each_compose_state_from_booleans_maps_per_group_handle():
+    fa = _make_features("A")
+    fb = _make_features("B")
+    fa.tags["cohort"] = "g1"
+    fb.tags["cohort"] = "g2"
+    fc = FeaturesCollection({"A": fa, "B": fb})
+    grouped = fc.groupby("cohort")
+
+    source = BatchResult(
+        {
+            "A": pd.Series([True, False, False, False], index=fa.tracking.data.index),
+            "B": pd.Series([False, True, False, False], index=fb.tracking.data.index),
+        },
+        fc,
+    )
+
+    states = grouped.each.compose_state_from_booleans({"zone": source})
+
+    assert isinstance(states, BatchResult)
+    assert states[("g1",)]["A"].tolist() == ["zone", "none", "none", "none"]
+    assert states[("g2",)]["B"].tolist() == ["none", "zone", "none", "none"]

--- a/tests/test_each_batch_modes.py
+++ b/tests/test_each_batch_modes.py
@@ -134,6 +134,20 @@ def test_each_non_matching_dict_is_broadcast_not_mapped():
     assert out["B"] is cfg
 
 
+def test_each_dict_with_embedded_batchresult_maps_embedded_values():
+    coll = _make_collection()
+    mapped = BatchResult({"A": "left", "B": "right"}, coll)
+    payload = {"label": mapped, "window": 3}
+
+    out = coll.each.passthrough(payload)
+
+    assert isinstance(out, BatchResult)
+    assert out["A"]["label"] == "left"
+    assert out["B"]["label"] == "right"
+    assert out["A"]["window"] == 3
+    assert out["B"]["window"] == 3
+
+
 def test_each_invalid_batchresult_mapping_raises():
     coll = _make_collection()
     bad = BatchResult({"A": "left"}, coll)  # missing B


### PR DESCRIPTION
### Summary
<!-- 
A short description of what this PR does.

Example:
- Adds aggregation functions for multi-animal keypoint trajectories.
-->
- allows dict of boolean-like series/BatchResult/column to be cast to single "state" series

### Type of change
<!-- 
At least one MUST be checked.
Use lowercase x exactly like this: [x]
-->
- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🧹 Chore / Refactor
- [ ] 📚 Docs

### User-facing change
<!-- 
This is what will appear in the release notes.
Write as a single bullet starting with - 

Example:
- Fixed incorrect body-angle computation when animals rotate >180°.
-->
- cast boolean results or columns to 'states'

### Testing
<!-- 
Explain how you tested the change.

Example:
- Added docstring tests covering interpolation of missing keypoints.
-->
- manual, bespoke, docstring
