### PR TITLE
ByStateDispatcher final

### DIFF
--- a/src/py3r/behaviour/summary/summary.py
+++ b/src/py3r/behaviour/summary/summary.py
@@ -617,9 +617,9 @@ class Summary:
         >>> res = s.by_state('state', all_states=['B', 'C', 'A']).sum_column('x')
         >>> res.value.index.tolist()
         ['B', 'C', 'A']
-        >>> res.value['C']  # inclusive all_states: state absent in data still included
+        >>> int(res.value['C'])  # inclusive all_states: state absent in data still included
         0
-        >>> res.value['B']
+        >>> int(res.value['B'])
         7
 
         ```

--- a/src/py3r/behaviour/summary/summary.py
+++ b/src/py3r/behaviour/summary/summary.py
@@ -21,6 +21,101 @@ from py3r.behaviour.util.io_utils import (
 from py3r.behaviour.util.series_utils import latencies_from_series
 
 
+def by_state_ok(func):
+    """Mark a Summary method as compatible with by_state dispatch."""
+    func._by_state_ok = True
+    return func
+
+
+class _ByStateDispatcher:
+    """Dynamic method dispatcher returned by :meth:`Summary.by_state`."""
+
+    def __init__(
+        self,
+        summary_obj: Summary,
+        state_column: str,
+        all_states: list | None = None,
+        max_states: int = 100,
+    ) -> None:
+        self._summary = summary_obj
+        self._state_column = state_column
+        self._all_states = all_states
+        self._max_states = max_states
+
+    def _make_subset_summary(self, mask: pd.Series) -> Summary:
+        # Use Features.loc to keep Tracking/Features slicing logic centralized.
+        subset_features = self._summary.features.loc[mask]
+        return Summary(subset_features)
+
+    def __getattr__(self, name: str):
+        attr = getattr(self._summary, name, None)
+        if not callable(attr):
+            raise AttributeError(f"'{self.__class__.__name__}' has no attribute '{name}'")
+        if not getattr(attr, "_by_state_ok", False):
+            raise NotImplementedError(
+                f"Summary.{name} is not marked as by_state-compatible. "
+                "Use a compatible method, or call this method without by_state."
+            )
+
+        def _wrapped(*args, **kwargs):
+            states_series = self._summary.features.data[self._state_column]
+            states = (
+                list(self._all_states)
+                if self._all_states is not None
+                else list(pd.unique(states_series.dropna()))
+            )
+            if len(states) > self._max_states:
+                raise ValueError(
+                    f"by_state('{self._state_column}') produced {len(states)} states, "
+                    f"exceeding max_states={self._max_states}. "
+                    "This often indicates a continuous-valued column was used as state. "
+                    "Pass a higher max_states if intentional."
+                )
+            out = {}
+            ylabel = None
+            for state in states:
+                mask = states_series == state
+                sub = self._make_subset_summary(mask)
+                result = getattr(sub, name)(*args, **kwargs)
+                if isinstance(result, SummaryResult) and ylabel is None:
+                    ylabel = result._ylabel
+                value = result.value if isinstance(result, SummaryResult) else result
+                if not pd.api.types.is_scalar(value):
+                    raise NotImplementedError(
+                        "by_state currently supports only Summary methods "
+                        "that return scalar values per state."
+                    )
+                out[state] = value
+            series = pd.Series(out)
+            meta = {
+                "function": f"{name}_by_state",
+                "state_column": self._state_column,
+                "all_states": states,
+                "args": args,
+                "kwargs": kwargs,
+            }
+            return SummaryResult(
+                series,
+                self._summary,
+                f"{name}_by_{self._state_column}",
+                meta,
+                ylabel=ylabel,
+            )
+
+        return _wrapped
+
+    def __dir__(self):
+        base = set(super().__dir__())
+        names = {
+            n
+            for n in dir(self._summary)
+            if not n.startswith("_")
+            and callable(getattr(self._summary, n, None))
+            and getattr(getattr(self._summary, n, None), "_by_state_ok", False)
+        }
+        return sorted(base | names)
+
+
 class Summary:
     """
     stores and computes summary statistics from features objects
@@ -351,6 +446,7 @@ class Summary:
         latency_s = latency / self.features.tracking.meta["fps"]
         return SummaryResult(latency_s, self, col, meta, ylabel="Latency (s)")
 
+    @by_state_ok
     def time_true(self, column: str) -> SummaryResult:
         """
         returns time in seconds that condition in the given column is true
@@ -387,6 +483,7 @@ class Summary:
         meta = {"function": "time_true", "column": column}
         return SummaryResult(time, self, f"time_true_{column}", meta, ylabel="Time (s)")
 
+    @by_state_ok
     def time_false(self, column: str) -> SummaryResult:
         """
         returns time in seconds that condition in the given column is false
@@ -423,6 +520,7 @@ class Summary:
         meta = {"function": "time_false", "column": column}
         return SummaryResult(time, self, f"time_false_{column}", meta, ylabel="Time (s)")
 
+    @by_state_ok
     def total_distance(
         self, point: str, startframe: int | None = None, endframe: int | None = None
     ) -> SummaryResult:
@@ -483,6 +581,56 @@ class Summary:
 
         raise TypeError("func must be callable.")
 
+    def by_state(
+        self, column: str, all_states: list | None = None, max_states: int = 100
+    ) -> _ByStateDispatcher:
+        """
+        Return a dynamic state-grouped dispatcher for Summary methods.
+
+        Parameters
+        ----------
+        column:
+            Name of the state column in ``features.data`` used to create per-state subsets.
+        all_states:
+            Optional explicit state list to define which states are evaluated and in what
+            output order. This list is inclusive: states not present in the data are still
+            evaluated on empty subsets and included in the output.
+        max_states:
+            Safety guard limiting the number of evaluated states. Raises ``ValueError`` if
+            the effective number of states exceeds this value.
+
+        Examples
+        --------
+        ```pycon
+        >>> import pandas as pd
+        >>> from py3r.behaviour.util.docdata import data_path
+        >>> from py3r.behaviour.tracking.tracking import Tracking
+        >>> from py3r.behaviour.features.features import Features
+        >>> from py3r.behaviour.summary.summary import Summary
+        >>> with data_path('py3r.behaviour.tracking._data', 'dlc_single.csv') as p:
+        ...     t = Tracking.from_dlc(str(p), handle='ex', fps=30)
+        >>> f = Features(t)
+        >>> idx = t.data.index
+        >>> f.store(pd.Series(['A', 'A', 'B', 'B', 'A'][:len(idx)], index=idx), 'state', meta={})
+        >>> f.store(pd.Series([1, 2, 3, 4, 5][:len(idx)], index=idx), 'x', meta={})
+        >>> s = Summary(f)
+        >>> res = s.by_state('state', all_states=['B', 'C', 'A']).sum_column('x')
+        >>> res.value.index.tolist()
+        ['B', 'C', 'A']
+        >>> res.value['C']  # inclusive all_states: state absent in data still included
+        0
+        >>> res.value['B']
+        7
+
+        ```
+        """
+        if column not in self.features.data.columns:
+            raise ValueError(f"Column '{column}' not found in features.data")
+        if max_states <= 0:
+            raise ValueError("max_states must be a positive integer")
+        return _ByStateDispatcher(self, column, all_states=all_states, max_states=max_states)
+
+    @by_state_ok
     def sum_column(self, column: str) -> SummaryResult:
         """
         Sum all non-NaN values in a `features.data` column and return as a SummaryResult.
@@ -509,6 +657,7 @@ class Summary:
         """
         return self._apply_column(column, pd.Series.sum, skipna=True)
 
+    @by_state_ok
     def mean_column(self, column: str) -> SummaryResult:
         """
         Mean of all non-NaN values in a `features.data` column and return as a SummaryResult.
@@ -535,6 +684,7 @@ class Summary:
         """
         return self._apply_column(column, pd.Series.mean, skipna=True)
 
+    @by_state_ok
     def median_column(self, column: str) -> SummaryResult:
         """
         Median of all non-NaN values in a `features.data` column and return as a SummaryResult.
@@ -561,6 +711,7 @@ class Summary:
         """
         return self._apply_column(column, pd.Series.median, skipna=True)
 
+    @by_state_ok
     def max_column(self, column: str) -> SummaryResult:
         """
         Max of all non-NaN values in a `features.data` column and return as a SummaryResult.
@@ -587,6 +738,7 @@ class Summary:
         """
         return self._apply_column(column, pd.Series.max, skipna=True)
 
+    @by_state_ok
     def min_column(self, column: str) -> SummaryResult:
         """
         Min of all non-NaN values in a `features.data` column and return as a SummaryResult.

--- a/src/py3r/behaviour/util/collection_utils.py
+++ b/src/py3r/behaviour/util/collection_utils.py
@@ -98,6 +98,33 @@ class BatchResult(dict):
     def store(self, *args, **kwargs):
         return self._parent_collection.store(self, *args, **kwargs)
 
+    @staticmethod
+    def _first_non_none_leaf(d):
+        for v in d.values():
+            if isinstance(v, BatchResult):
+                leaf = BatchResult._first_non_none_leaf(v)
+                if leaf is not None:
+                    return leaf
+            elif v is not None:
+                return v
+        return None
+
+    def __getattr__(self, name: str):
+        if name.startswith("_"):
+            raise AttributeError(f"BatchResult has no attribute '{name}'")
+
+        leaf = self._first_non_none_leaf(self)
+        if leaf is None:
+            raise AttributeError(f"BatchResult has no attribute '{name}'")
+        attr = getattr(leaf, name, None)
+        if not callable(attr):
+            raise AttributeError(f"BatchResult has no callable attribute '{name}'")
+
+        def _leaf_call(*args, **kwargs):
+            return self._apply_to_leaves(lambda v: getattr(v, name)(*args, **kwargs))
+
+        return _leaf_call
+
     # ----- Convenience: functional transforms and simple arithmetic on results -----
     def _apply_to_leaves(self, fn):
         """

--- a/tests/test_each_batch_modes.py
+++ b/tests/test_each_batch_modes.py
@@ -30,6 +30,17 @@ class DummyLeaf:
     def passthrough(self, value):
         return value
 
+    def by_state(self):
+        return _DummyByState(self.handle)
+
+
+class _DummyByState:
+    def __init__(self, handle: str):
+        self.handle = handle
+
+    def method(self, value: str) -> str:
+        return f"{self.handle}:{value}"
+
 
 class DummyCollection(BaseCollection):
     _element_type = DummyLeaf
@@ -146,6 +157,26 @@ def test_each_dict_with_embedded_batchresult_maps_embedded_values():
     assert out["B"]["label"] == "right"
     assert out["A"]["window"] == 3
     assert out["B"]["window"] == 3
+
+
+def test_batchresult_supports_chained_method_dispatch_on_leaves():
+    coll = _make_collection()
+
+    out = coll.each.by_state().method("ok")
+
+    assert isinstance(out, BatchResult)
+    assert out["A"] == "A:ok"
+    assert out["B"] == "B:ok"
+
+
+def test_grouped_batchresult_supports_chained_method_dispatch_on_leaves():
+    grouped = _make_collection().groupby("group")
+
+    out = grouped.each.by_state().method("ok")
+
+    assert isinstance(out, BatchResult)
+    assert out[("g1",)]["A"] == "A:ok"
+    assert out[("g2",)]["B"] == "B:ok"
 
 
 def test_each_invalid_batchresult_mapping_raises():

--- a/tests/test_summary_by_state.py
+++ b/tests/test_summary_by_state.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from py3r.behaviour.features.features import Features
+from py3r.behaviour.summary.summary import Summary
+from py3r.behaviour.tracking.tracking import Tracking
+
+
+def _make_summary_with_state_and_value(
+    states: list[str], values: list[float], fps: float = 2.0
+) -> Summary:
+    n_frames = len(states)
+    tracking_df = pd.DataFrame(
+        {
+            "bp.x": [float(i) for i in range(n_frames)],
+            "bp.y": [0.0 for _ in range(n_frames)],
+        },
+        index=pd.RangeIndex(n_frames, name="frame"),
+    )
+    tracking = Tracking(
+        tracking_df,
+        {"fps": fps, "rescale_distance_method": "dummy"},
+        handle="ex",
+    )
+    features = Features(tracking)
+    features.store(pd.Series(states, index=tracking_df.index, name="state"), "state", meta={})
+    features.store(pd.Series(values, index=tracking_df.index, name="x"), "x", meta={})
+    return Summary(features)
+
+
+def test_by_state_min_column_returns_series_per_state():
+    summary = _make_summary_with_state_and_value(["A", "A", "B", "A"], [2, 1, 9, 3])
+
+    result = summary.by_state("state").min_column("x")
+
+    assert set(result.value.index.tolist()) == {"A", "B"}
+    assert result.value["A"] == 1
+    assert result.value["B"] == 9
+
+
+def test_by_state_sum_column_respects_all_states_order():
+    summary = _make_summary_with_state_and_value(["A", "A", "B", "A"], [2, 1, 9, 3])
+
+    result = summary.by_state("state", all_states=["B", "C", "A"]).sum_column("x")
+
+    assert result.value.index.tolist() == ["B", "C", "A"]
+    assert result.value["B"] == 9
+    assert result.value["C"] == 0
+    assert result.value["A"] == 6
+    assert result._params["all_states"] == ["B", "C", "A"]
+
+
+def test_by_state_missing_state_column_raises():
+    summary = _make_summary_with_state_and_value(["A", "A", "B"], [1, 2, 3])
+
+    with pytest.raises(ValueError, match="Column 'missing' not found in features.data"):
+        summary.by_state("missing")
+
+
+def test_by_state_missing_value_column_raises():
+    summary = _make_summary_with_state_and_value(["A", "A", "B"], [1, 2, 3])
+
+    with pytest.raises(ValueError, match="Column 'missing' not found in features.data"):
+        summary.by_state("state").mean_column("missing")
+
+
+def test_by_state_returns_summary_type():
+    summary = _make_summary_with_state_and_value(["A", "A", "B"], [1, 2, 3])
+
+    scoped = summary.by_state("state")
+
+    assert not isinstance(scoped, Summary)
+    assert "min_column" in dir(scoped)
+
+
+def test_unscoped_only_method_raises_on_state_scoped_summary():
+    summary = _make_summary_with_state_and_value(["A", "A", "B"], [1, 2, 3])
+
+    with pytest.raises(NotImplementedError, match="not marked as by_state-compatible"):
+        summary.by_state("state").time_in_state("state")
+
+
+def test_by_state_supports_time_true_and_time_false():
+    summary = _make_summary_with_state_and_value(["A", "A", "B", "B"], [1, 2, 3, 4])
+    summary.features.store(
+        pd.Series([True, False, True, True], index=summary.features.tracking.data.index),
+        "flag",
+        meta={},
+    )
+
+    true_res = summary.by_state("state").time_true("flag")
+    false_res = summary.by_state("state").time_false("flag")
+
+    assert true_res.value["A"] == 0.5
+    assert true_res.value["B"] == 1.0
+    assert false_res.value["A"] == 0.5
+    assert false_res.value["B"] == 0.0
+    assert true_res._ylabel == "Time (s)"
+    assert false_res._ylabel == "Time (s)"
+
+
+def test_by_state_all_states_is_inclusive_for_missing_state():
+    summary = _make_summary_with_state_and_value(["A", "A", "B", "B"], [1, 2, 3, 4])
+    summary.features.store(
+        pd.Series([True, False, True, True], index=summary.features.tracking.data.index),
+        "flag",
+        meta={},
+    )
+
+    true_res = summary.by_state("state", all_states=["A", "B", "C"]).time_true("flag")
+
+    assert true_res.value.index.tolist() == ["A", "B", "C"]
+    assert true_res.value["A"] == 0.5
+    assert true_res.value["B"] == 1.0
+    assert true_res.value["C"] == 0.0
+
+
+def test_by_state_supports_total_distance():
+    summary = _make_summary_with_state_and_value(["A", "A", "B", "B"], [1, 2, 3, 4])
+
+    result = summary.by_state("state").total_distance("bp")
+
+    assert set(result.value.index.tolist()) == {"A", "B"}
+    assert result.value["A"] > 0
+    assert result.value["B"] > 0
+    assert result._ylabel == "Distance (a.u.)"
+
+
+def test_by_state_dir_lists_only_marked_methods():
+    summary = _make_summary_with_state_and_value(["A", "A", "B"], [1, 2, 3])
+
+    names = dir(summary.by_state("state"))
+
+    assert "min_column" in names
+    assert "time_true" in names
+    assert "time_in_state" not in names
+
+
+def test_by_state_max_states_guard_raises_helpful_error():
+    summary = _make_summary_with_state_and_value(["A", "A", "B"], [1, 2, 3])
+
+    with pytest.raises(ValueError, match="exceeding max_states=1"):
+        summary.by_state("state", max_states=1).min_column("x")


### PR DESCRIPTION
### Summary
<!-- 
A short description of what this PR does.

Example:
- Adds aggregation functions for multi-animal keypoint trajectories.
-->
- allows calculation of scalar Summary results by state (e.g. total_distance by cluster)

### Type of change
<!-- 
At least one MUST be checked.
Use lowercase x exactly like this: [x]
-->
- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🧹 Chore / Refactor
- [ ] 📚 Docs

### User-facing change
<!-- 
This is what will appear in the release notes.
Write as a single bullet starting with - 

Example:
- Fixed incorrect body-angle computation when animals rotate >180°.
-->
- allows calculation of scalar Summary results by state (e.g. total_distance by cluster)

### Testing
<!-- 
Explain how you tested the change.

Example:
- Added docstring tests covering interpolation of missing keypoints.
-->
- manual, docstrings, bespoke
