### PR TITLE
Bugfix/nan smooth block

### DIFF
--- a/src/py3r/behaviour/features/features.py
+++ b/src/py3r/behaviour/features/features.py
@@ -1657,10 +1657,9 @@ class Features:
             'mean' : mean in window (numerical)
             'savgol' : Savitzky–Golay (SciPy). Kwargs e.g. polyorder=3, mode='interp'.
             'mode' : mode in window (numerical or non-numerical)
-            'block' : removes labels that occur in blocks of less than length window
-                      and replaces them with value from previous block unless there is
-                      no previous block, in which case replaced from next block after smoothing
-                      note: all nan values will be filled using this method (dangerous!)
+            'block' : applies categorical series_utils.block_filter then series_utils.block_fill
+                      using window for both min_block and max_gap. Legacy smooth_block behavior is
+                      removed from this method; use series_utils.smooth_block directly if required.
         """
         if "smoothing" in self.meta[name].keys():
             raise Exception("feature already smoothed")
@@ -1675,7 +1674,20 @@ class Features:
             if inplace:
                 self.data[name] = smoothed.copy()
         elif method == "block":
-            smoothed = series_utils.smooth_block(self.data[name], window)
+            warnings.warn(
+                "Legacy block behavior in Features.smooth(method='block') was removed. "
+                "This now applies series_utils.block_filter followed by series_utils.block_fill "
+                "using window for both min_block and max_gap. "
+                "Deprecated legacy behavior remains available via series_utils.smooth_block.",
+                stacklevel=2,
+            )
+            filtered = series_utils.block_filter(self.data[name], min_block=window)
+            smoothed = series_utils.block_fill(
+                filtered,
+                max_gap=window,
+                direction=method_kwargs.get("fill_direction", "both"),
+                require_same_label=method_kwargs.get("fill_require_same_label", True),
+            )
             if inplace:
                 self.data[name] = smoothed.copy()
         else:

--- a/src/py3r/behaviour/util/series_utils.py
+++ b/src/py3r/behaviour/util/series_utils.py
@@ -36,11 +36,19 @@ def gen_encoder_decoder(s: pd.Series):
 
 def smooth_block(s: pd.Series, window: int) -> pd.Series:
     """
+    deprecated: use block_filter and block_fill instead
+
     drop labels that occur in blocks of less than window
     replace them with value from previous block in the series
     unless there is no previous block, in which case it fills
     from next block
     """
+
+    warnings.warn(
+        "smooth_block is deprecated, use block_filter and block_fill instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
     encoder, decoder = gen_encoder_decoder(s)
 
@@ -59,6 +67,101 @@ def smooth_block(s: pd.Series, window: int) -> pd.Series:
     output = pd.Series([decoder[i] for i in _["s"]])
 
     return output
+
+
+def block_filter(s: pd.Series, min_block: int = 2) -> pd.Series:
+    """
+    Mark short observed categorical blocks as np.nan.
+
+    Existing missing values are preserved. Only contiguous non-missing runs
+    of identical labels are considered "blocks".
+
+    Parameters
+    ----------
+    s : pd.Series
+        Input categorical series.
+    min_block : int, default 2
+        Minimum block length to keep. Blocks shorter than this are replaced
+        with ``np.nan``.
+    """
+    if not isinstance(min_block, int) or min_block < 1:
+        raise ValueError("min_block must be an integer >= 1")
+
+    out = s.copy()
+    observed = s.notna()
+    # New run starts when we hit observed data after a gap, or when label changes.
+    run_starts = observed & ((~observed.shift(fill_value=False)) | s.ne(s.shift()))
+    run_ids = run_starts.cumsum().where(observed)
+    run_lengths = run_ids.groupby(run_ids).transform("size")
+    out.loc[observed & (run_lengths < min_block)] = np.nan
+
+    return out
+
+
+def block_fill(
+    s: pd.Series,
+    *,
+    max_gap: int = 1,
+    direction: Literal["forward", "backward", "both"] = "both",
+    require_same_label: bool = True,
+) -> pd.Series:
+    """
+    Fill short missing runs in categorical data using local neighbors only.
+
+    Parameters
+    ----------
+    s : pd.Series
+        Input categorical series.
+    max_gap : int, default 1
+        Maximum length of a missing run to fill. Longer runs are left missing.
+    direction : {"forward", "backward", "both"}, default "both"
+        Neighbor direction used for fill.
+    require_same_label : bool, default True
+        Only applies when ``direction="both"``. If True, a gap is filled only
+        when both bracketing labels exist and are equal.
+    """
+    if not isinstance(max_gap, int) or max_gap < 0:
+        raise ValueError("max_gap must be an integer >= 0")
+    if direction not in {"forward", "backward", "both"}:
+        raise ValueError("direction must be one of: 'forward', 'backward', 'both'")
+    if max_gap == 0:
+        return s.copy()
+
+    out = s.copy()
+    na_mask = s.isna().to_numpy()
+    edges = np.diff(np.concatenate(([0], na_mask.astype(np.int8), [0])))
+    starts = np.where(edges == 1)[0]
+    ends = np.where(edges == -1)[0]
+
+    for start, end in zip(starts, ends, strict=True):
+        gap_len = end - start
+        if gap_len > max_gap:
+            continue
+
+        left_exists = start > 0 and pd.notna(out.iloc[start - 1])
+        right_exists = end < len(out) and pd.notna(out.iloc[end])
+
+        fill_value = None
+        if direction == "forward":
+            if left_exists:
+                fill_value = out.iloc[start - 1]
+        elif direction == "backward":
+            if right_exists:
+                fill_value = out.iloc[end]
+        else:
+            if require_same_label:
+                if left_exists and right_exists and out.iloc[start - 1] == out.iloc[end]:
+                    fill_value = out.iloc[start - 1]
+            else:
+                if left_exists:
+                    fill_value = out.iloc[start - 1]
+                elif right_exists:
+                    fill_value = out.iloc[end]
+
+        if fill_value is not None:
+            out.iloc[start:end] = fill_value
+
+    return out
 
 
 def get_block(s: pd.Series, window: int) -> pd.Series:

--- a/tests/test_features_smooth_block.py
+++ b/tests/test_features_smooth_block.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from py3r.behaviour.features.features import Features
+from py3r.behaviour.tracking.tracking import Tracking
+from py3r.behaviour.util import series_utils
+
+
+def _make_features(handle: str = "A", n_frames: int = 8) -> Features:
+    tracking_df = pd.DataFrame(
+        {
+            "bp.x": [float(i) for i in range(n_frames)],
+            "bp.y": [0.0 for _ in range(n_frames)],
+        },
+        index=pd.RangeIndex(n_frames, name="frame"),
+    )
+    tracking = Tracking(
+        tracking_df,
+        {"fps": 30.0, "rescale_distance_method": "dummy"},
+        handle=handle,
+    )
+    return Features(tracking)
+
+
+def test_smooth_block_warns_and_uses_new_pipeline():
+    f = _make_features()
+    s = pd.Series(["A", "A", np.nan, "A", "B", np.nan, "B", "B"], index=f.tracking.data.index)
+    f.store(s, "state")
+
+    expected = series_utils.block_fill(
+        series_utils.block_filter(s, min_block=2),
+        max_gap=2,
+        direction="both",
+        require_same_label=True,
+    )
+
+    with pytest.warns(UserWarning, match="Legacy block behavior"):
+        out = f.smooth("state", method="block", window=2, inplace=False)
+
+    assert out.tolist() == expected.tolist()
+    # inplace=False should still leave source feature unchanged.
+    assert f.data["state"].tolist() == s.tolist()
+
+
+def test_smooth_block_accepts_fill_kwargs():
+    f = _make_features()
+    s = pd.Series(["A", np.nan, "B"], index=f.tracking.data.index[:3])
+    f.store(s, "state2")
+
+    with pytest.warns(UserWarning, match="Legacy block behavior"):
+        out = f.smooth(
+            "state2",
+            method="block",
+            window=1,
+            inplace=False,
+            fill_direction="backward",
+            fill_require_same_label=True,
+        )
+
+    # Backward fill should select right label for the single-frame gap.
+    assert out.tolist() == ["A", "B", "B"]

--- a/tests/test_series_utils_categorical.py
+++ b/tests/test_series_utils_categorical.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from pandas.testing import assert_series_equal
+
+from py3r.behaviour.util.series_utils import block_fill, block_filter
+
+
+def test_block_filter_marks_short_observed_blocks_only():
+    s = pd.Series(["A", "A", np.nan, np.nan, "A"], dtype="object")
+    out = block_filter(s, min_block=2)
+    expected = pd.Series(["A", "A", np.nan, np.nan, np.nan], dtype="object")
+    assert_series_equal(out, expected)
+
+
+def test_block_filter_treats_nan_as_block_separator():
+    s = pd.Series(["A", "A", np.nan, "A", "A"], dtype="object")
+    out = block_filter(s, min_block=3)
+    expected = pd.Series([np.nan, np.nan, np.nan, np.nan, np.nan], dtype="object")
+    assert_series_equal(out, expected)
+
+
+def test_block_fill_bridges_only_short_bracketed_gaps():
+    s_short = pd.Series(["A", np.nan, "A"], dtype="object")
+    out_short = block_fill(
+        s_short,
+        max_gap=1,
+        direction="both",
+        require_same_label=True,
+    )
+    expected_short = pd.Series(["A", "A", "A"], dtype="object")
+    assert_series_equal(out_short, expected_short)
+
+    s_long = pd.Series(["A", np.nan, np.nan, "A"], dtype="object")
+    out_long = block_fill(
+        s_long,
+        max_gap=1,
+        direction="both",
+        require_same_label=True,
+    )
+    assert_series_equal(out_long, s_long)
+
+
+def test_block_fill_respects_direction_and_label_requirement():
+    s = pd.Series(["A", np.nan, "B"], dtype="object")
+
+    out_both_strict = block_fill(
+        s,
+        max_gap=1,
+        direction="both",
+        require_same_label=True,
+    )
+    assert_series_equal(out_both_strict, s)
+
+    out_both_relaxed = block_fill(
+        s,
+        max_gap=1,
+        direction="both",
+        require_same_label=False,
+    )
+    expected_both_relaxed = pd.Series(["A", "A", "B"], dtype="object")
+    assert_series_equal(out_both_relaxed, expected_both_relaxed)
+
+    out_backward = block_fill(
+        s,
+        max_gap=1,
+        direction="backward",
+        require_same_label=True,
+    )
+    expected_backward = pd.Series(["A", "B", "B"], dtype="object")
+    assert_series_equal(out_backward, expected_backward)
+
+
+def test_block_filter_then_fill_keeps_long_gap_missing():
+    s = pd.Series(["A", "A", np.nan, np.nan, "A"], dtype="object")
+    smoothed = block_filter(s, min_block=2)
+    out = block_fill(
+        smoothed,
+        max_gap=1,
+        direction="both",
+        require_same_label=True,
+    )
+    expected = pd.Series(["A", "A", np.nan, np.nan, np.nan], dtype="object")
+    assert_series_equal(out, expected)


### PR DESCRIPTION
### Summary
<!-- 
A short description of what this PR does.

Example:
- Adds aggregation functions for multi-animal keypoint trajectories.
-->
- implemented block_filter and block_fill methods to replace smooth_block

### Type of change
<!-- 
At least one MUST be checked.
Use lowercase x exactly like this: [x]
-->
- [x] ✨ Feature
- [x] 🐛 Bug fix
- [x] 💥 Breaking change
- [ ] 🧹 Chore / Refactor
- [ ] 📚 Docs

### User-facing change
<!-- 
This is what will appear in the release notes.
Write as a single bullet starting with - 

Example:
- Fixed incorrect body-angle computation when animals rotate >180°.
-->
- improved block-smoothing of categorical features

### Testing
<!-- 
Explain how you tested the change.

Example:
- Added docstring tests covering interpolation of missing keypoints.
-->
- bespoke, manual, docstrings
