### PR TITLE
clustering: individual normalisation and CentroidsDf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 .venv
+.venv*/
 .venv_temp
 .DS_Store
 __pycache__/
 *.egg-info/
+build/
 dev/
 .pytest_cache/
 site/

--- a/src/py3r/behaviour/features/centroids_df.py
+++ b/src/py3r/behaviour/features/centroids_df.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True, slots=True)
+class CentroidsDf:
+    """
+    Lightweight, DataFrame-like wrapper for clustering centroids and their scaling recipe.
+
+    This is a delegating wrapper (not a pd.DataFrame subclass). It behaves like a
+    DataFrame for common read-only usage via attribute delegation, but additionally
+    carries a ``scaling_recipe`` with everything needed to reproduce the normalisation
+    and weighting applied during clustering, for use on future datasets.
+
+    Treat instances as immutable. Most delegated DataFrame operations return a plain
+    ``pd.DataFrame`` and will not preserve the recipe. Use ``.to_df()`` if you need
+    the underlying DataFrame explicitly.
+
+    The ``scaling_recipe`` schema (version 1)::
+
+        {
+            "version": 1,
+            "embedding_dict": dict[str, list[int]],
+            "columns": list[str],
+            "normalize_individual_base": dict[str, bool],  # keyed by base feature name
+            "constant_factors": dict[str, float],          # keyed by embedding column
+        }
+
+    Workflow
+    --------
+    1. Fit::
+
+           batch, centroids, sf = fc.cluster_embedding(...)
+           # centroids is a CentroidsDf
+
+    2. Save::
+
+           centroids.save("my_run/")
+
+    3. Later::
+
+           centroids = CentroidsDf.load("my_run/")
+
+    4. Apply to new data::
+
+           feat.assign_clusters_by_centroids(emb, centroids)
+    """
+
+    df: pd.DataFrame
+    scaling_recipe: dict[str, Any]
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.df, pd.DataFrame):
+            raise TypeError(f"df must be a pandas DataFrame, got {type(self.df)}")
+        if not isinstance(self.scaling_recipe, dict):
+            raise TypeError(f"scaling_recipe must be a dict, got {type(self.scaling_recipe)}")
+
+    # --- DataFrame delegation ------------------------------------------------
+
+    def __getattr__(self, name: str):
+        # Only called when attribute is not found on the wrapper itself.
+        return getattr(self.df, name)
+
+    def __len__(self) -> int:
+        return len(self.df)
+
+    def __iter__(self):
+        return iter(self.df)
+
+    def __getitem__(self, key):
+        return self.df[key]
+
+    def __repr__(self) -> str:
+        return repr(self.df)
+
+    def _repr_html_(self) -> str:  # pragma: no cover
+        return self.df._repr_html_()
+
+    def __array__(self, dtype=None) -> np.ndarray:  # pragma: no cover
+        return np.asarray(self.df, dtype=dtype)
+
+    def to_df(self) -> pd.DataFrame:
+        """Return the underlying centroids DataFrame (no copy)."""
+        return self.df
+
+    # --- Persistence ---------------------------------------------------------
+
+    @property
+    def _meta_payload(self) -> dict[str, Any]:
+        return {"schema_version": self.schema_version, "scaling_recipe": self.scaling_recipe}
+
+    def save(self, path: str | Path) -> Path:
+        """
+        Persist centroids and scaling recipe to disk.
+
+        If *path* ends with ``/`` or is an existing directory, writes:
+
+        - ``centroids.parquet``
+        - ``meta.json``
+
+        Otherwise uses *path* as a stem:
+
+        - ``<stem>.parquet``
+        - ``<stem>.json``
+
+        Returns the path of the written parquet file.
+        """
+        p = Path(path)
+        if str(path).endswith(("/", "\\")) or (p.exists() and p.is_dir()):
+            out_dir = p
+            out_dir.mkdir(parents=True, exist_ok=True)
+            df_path = out_dir / "centroids.parquet"
+            meta_path = out_dir / "meta.json"
+        else:
+            out_dir = p.parent
+            out_dir.mkdir(parents=True, exist_ok=True)
+            df_path = p.with_suffix(".parquet")
+            meta_path = p.with_suffix(".json")
+
+        self.df.to_parquet(df_path)
+        meta_path.write_text(json.dumps(self._meta_payload, indent=2, sort_keys=True))
+        return df_path
+
+    @classmethod
+    def load(cls, path: str | Path) -> CentroidsDf:
+        """
+        Load a previously saved ``CentroidsDf``.
+
+        Accepts either:
+
+        - a directory containing ``centroids.parquet`` + ``meta.json``
+        - a stem path (reads ``<stem>.parquet`` + ``<stem>.json``)
+        """
+        p = Path(path)
+        if p.exists() and p.is_dir():
+            df_path = p / "centroids.parquet"
+            meta_path = p / "meta.json"
+        else:
+            df_path = p.with_suffix(".parquet")
+            meta_path = p.with_suffix(".json")
+
+        df = pd.read_parquet(df_path)
+        meta = json.loads(meta_path.read_text())
+        schema_version = int(meta.get("schema_version", 1))
+        scaling_recipe = dict(meta.get("scaling_recipe", {}))
+        return cls(df=df, scaling_recipe=scaling_recipe, schema_version=schema_version)

--- a/src/py3r/behaviour/features/centroids_df.py
+++ b/src/py3r/behaviour/features/centroids_df.py
@@ -31,7 +31,7 @@ class CentroidsDf:
             "columns": list[str],
             "normalize_individual_base": dict[str, bool],      # keyed by base feature name
             "constant_factors": dict[str, float],              # keyed by embedding column
-            "impute_medians": dict[str, float] | None,         # None when missing_policy="drop"
+            "impute_means": dict[str, float] | None,            # None when missing_policy="drop"
         }
 
     Workflow

--- a/src/py3r/behaviour/features/centroids_df.py
+++ b/src/py3r/behaviour/features/centroids_df.py
@@ -29,8 +29,9 @@ class CentroidsDf:
             "version": 1,
             "embedding_dict": dict[str, list[int]],
             "columns": list[str],
-            "normalize_individual_base": dict[str, bool],  # keyed by base feature name
-            "constant_factors": dict[str, float],          # keyed by embedding column
+            "normalize_individual_base": dict[str, bool],      # keyed by base feature name
+            "constant_factors": dict[str, float],              # keyed by embedding column
+            "impute_medians": dict[str, float] | None,         # None when missing_policy="drop"
         }
 
     Workflow
@@ -50,7 +51,8 @@ class CentroidsDf:
 
     4. Apply to new data::
 
-           feat.assign_clusters_by_centroids(emb, centroids)
+           feat.assign_clusters_by_centroids(centroids)
+           # embedding and all necessary transformation info are contained in centroids object
     """
 
     df: pd.DataFrame
@@ -126,7 +128,7 @@ class CentroidsDf:
             meta_path = p.with_suffix(".json")
 
         self.df.to_parquet(df_path)
-        meta_path.write_text(json.dumps(self._meta_payload, indent=2, sort_keys=True))
+        meta_path.write_text(json.dumps(self._meta_payload, indent=2))
         return df_path
 
     @classmethod

--- a/src/py3r/behaviour/features/cluster_pipeline.py
+++ b/src/py3r/behaviour/features/cluster_pipeline.py
@@ -87,6 +87,7 @@ class ClusteringConfig:
     n_clusters: int
     random_state: int = 0
     normalize: bool = False
+    normalize_details: dict[str, Literal["individual", "global", "none"]] | None = None
     feature_weights: dict[str, float] | None = None
     auto_normalize: bool = False
     rescale_factors: dict | None = None
@@ -246,7 +247,6 @@ class ClusteringPipeline:
         embedding_dict: dict[str, list[int]],
         cfg: ClusteringConfig,
     ) -> tuple[dict, pd.DataFrame, dict | None, dict]:
-        using_new = cfg.normalize or cfg.feature_weights is not None
         if cfg.auto_normalize:
             raise NotImplementedError("auto_normalize was removed; use normalize=True instead.")
         if cfg.rescale_factors is not None:
@@ -262,21 +262,64 @@ class ClusteringPipeline:
             lowmem=cfg.lowmem,
             decimation_factor=cfg.decimation_factor,
         )
-        resolved_weights = None
+
+        using_new = (
+            cfg.normalize or cfg.feature_weights is not None or cfg.normalize_details is not None
+        )
+
+        resolved_weights: dict[str, float] | None = None
+        resolved_norm: dict[str, Literal["individual", "global", "none"]] = {}
+        global_base_stds: dict[str, float] = {}
+
         if using_new:
+            first_feat = next(_iter_features(fc))[2]
+            embed_cols = list(first_feat.embedding_df(embedding_dict).columns)
+
             if cfg.feature_weights is not None:
-                resolved_weights = _resolve_feature_weights(
-                    build.combined.columns, cfg.feature_weights
-                )
-            norm = _compute_scaling_factors(
-                fc,
-                embedding_dict,
-                normalize=cfg.normalize,
-                resolved_weights=resolved_weights,
+                resolved_weights = _resolve_feature_weights(embed_cols, cfg.feature_weights)
+
+            default_mode: Literal["global", "none"] = "global" if cfg.normalize else "none"
+            resolved_norm = _resolve_column_modes(
+                embed_cols, cfg.normalize_details, default=default_mode
             )
-            combined = build.combined
-            if norm is not None:
-                combined = combined * pd.Series(norm)
+
+            bases_needed = {
+                _base_feature_for_column(c, embedding_dict)
+                for c, m in resolved_norm.items()
+                if m == "global"
+            }
+            global_base_stds = _compute_global_base_stds(
+                fc, embedding_dict, bases_needed=bases_needed
+            )
+
+            constant_factors = _constant_scaling_factors(
+                embed_cols,
+                embedding_dict,
+                resolved_norm=resolved_norm,
+                resolved_weights=resolved_weights,
+                global_base_stds=global_base_stds,
+            )
+            norm = constant_factors
+
+            has_individual = any(m == "individual" for m in resolved_norm.values())
+            if has_individual:
+                combined = _apply_per_features_scaling(
+                    build.combined,
+                    fc,
+                    embedding_dict,
+                    resolved_norm=resolved_norm,
+                    resolved_weights=resolved_weights,
+                    global_base_stds=global_base_stds,
+                    flat_key=build.flat_group_key,
+                )
+            else:
+                combined = build.combined
+                if constant_factors is not None:
+                    combined = combined * pd.Series(constant_factors)
+
+            scaling_recipe = _build_scaling_recipe(
+                embedding_dict, embed_cols, resolved_norm, constant_factors
+            )
         else:
             combined, norm = self.pre.scale(
                 build.combined,
@@ -284,6 +327,11 @@ class ClusteringPipeline:
                 rescale_factors=cfg.rescale_factors,
                 custom_scaling=cfg.custom_scaling,
             )
+            first_feat = next(_iter_features(fc))[2]
+            embed_cols = list(first_feat.embedding_df(embedding_dict).columns)
+            resolved_norm = {c: "none" for c in embed_cols}
+            scaling_recipe = _build_scaling_recipe(embedding_dict, embed_cols, resolved_norm, norm)
+
         X, w, impute_medians, valid_mask = self.missing.prepare(combined, cfg.missing_policy)
         model, centroids = self.clusterer.fit(
             X, sample_weight=w, n_clusters=cfg.n_clusters, random_state=cfg.random_state
@@ -294,6 +342,7 @@ class ClusteringPipeline:
             "n_clusters": cfg.n_clusters,
             "random_state": cfg.random_state,
             "normalize": cfg.normalize,
+            "normalize_details": cfg.normalize_details,
             "feature_weights": cfg.feature_weights,
             "resolved_feature_weights": resolved_weights,
             "auto_normalize": cfg.auto_normalize,
@@ -302,6 +351,7 @@ class ClusteringPipeline:
             "decimation_factor": cfg.decimation_factor,
             "missing_policy": cfg.missing_policy,
             "impute_medians": None if impute_medians is None else impute_medians.to_dict(),
+            "scaling_recipe": scaling_recipe,
         }
 
         if cfg.lowmem:
@@ -309,10 +359,17 @@ class ClusteringPipeline:
                 is_grouped = getattr(fc, "is_grouped", False)
                 result_dict = {}
                 for gkey, feat_name, feat in _iter_features(fc):
+                    per_sf = _scaling_for_features(
+                        feat,
+                        embedding_dict,
+                        resolved_norm=resolved_norm,
+                        resolved_weights=resolved_weights,
+                        global_base_stds=global_base_stds,
+                    )
                     fr = feat.assign_clusters_by_centroids(
                         embedding_dict,
                         centroids,
-                        scaling_factors=norm,
+                        scaling_factors=per_sf,
                         impute_medians=impute_medians,
                     )
                     if is_grouped:
@@ -365,6 +422,7 @@ class StreamingConfig:
     n_clusters: int
     random_state: int = 0
     normalize: bool = False
+    normalize_details: dict[str, Literal["individual", "global", "none"]] | None = None
     feature_weights: dict[str, float] | None = None
     missing_policy: Literal["drop", "impute_weight"] = "drop"
     chunk_size: int = 10_000
@@ -417,72 +475,242 @@ def _base_feature_for_column(col: str, embedding_dict: dict[str, list[int]]) -> 
     raise ValueError(f"Cannot determine base feature for embedding column '{col}'")
 
 
-def _compute_scaling_factors(
+# ---------------------------------------------------------------------------
+# Normalisation helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_column_modes(
+    columns: list[str] | pd.Index,
+    normalize_details: dict[str, Literal["individual", "global", "none"]] | None,
+    *,
+    default: Literal["global", "none"],
+) -> dict[str, Literal["individual", "global", "none"]]:
+    """
+    Resolve substring→mode rules into a per-column mode dict.
+
+    Rules are matched by substring against full embedding column names.
+    Raises ValueError if any rule matches no columns or any column matches
+    multiple rules (overlap/ambiguity).
+    """
+    cols = list(columns)
+    if not normalize_details:
+        return {c: default for c in cols}
+
+    matched_counts = {rule: 0 for rule in normalize_details}
+    out: dict[str, Literal["individual", "global", "none"]] = {}
+    for c in cols:
+        matches = [rule for rule in normalize_details if rule in c]
+        if len(matches) > 1:
+            raise ValueError(f"normalize_details rules overlap for column '{c}': {matches}")
+        if len(matches) == 0:
+            out[c] = default
+        else:
+            rule = matches[0]
+            matched_counts[rule] += 1
+            out[c] = normalize_details[rule]
+
+    unused = [r for r, n in matched_counts.items() if n == 0]
+    if unused:
+        raise ValueError(f"normalize_details rules matched no columns: {unused}")
+    return out
+
+
+def _safe_std(x: np.ndarray) -> float:
+    """Std of finite values in *x*; returns 1.0 if empty or zero."""
+    finite = x[np.isfinite(x)]
+    if finite.size == 0:
+        return 1.0
+    std = float(np.std(finite))
+    return std if std > 0 else 1.0
+
+
+def _compute_global_base_stds(
     fc,
     embedding_dict: dict[str, list[int]],
     *,
-    normalize: bool,
+    bases_needed: set[str],
+) -> dict[str, float]:
+    """
+    Compute global std for each base feature in *bases_needed*, pooled across
+    the entire collection.  Returns an empty dict when *bases_needed* is empty.
+    """
+    if not bases_needed:
+        return {}
+    col_sum: dict[str, float] = {b: 0.0 for b in bases_needed}
+    col_sq: dict[str, float] = {b: 0.0 for b in bases_needed}
+    col_n: dict[str, int] = {b: 0 for b in bases_needed}
+    for _gk, _fn, feat in _iter_features(fc):
+        for base in bases_needed:
+            vals = feat.data[base].to_numpy(dtype=np.float64)
+            finite = vals[np.isfinite(vals)]
+            col_sum[base] += float(finite.sum())
+            col_sq[base] += float((finite**2).sum())
+            col_n[base] += int(finite.size)
+    result: dict[str, float] = {}
+    for base in bases_needed:
+        n = col_n[base]
+        if n == 0:
+            result[base] = 1.0
+        else:
+            mean = col_sum[base] / n
+            std = float(np.sqrt(max(0.0, col_sq[base] / n - mean**2)))
+            result[base] = std if std > 0 else 1.0
+    return result
+
+
+def _scaling_for_features(
+    feat: Features,
+    embedding_dict: dict[str, list[int]],
+    *,
+    resolved_norm: dict[str, Literal["individual", "global", "none"]],
     resolved_weights: dict[str, float] | None,
+    global_base_stds: dict[str, float],
 ) -> dict[str, float] | None:
-    """Compute combined per-embedding-column scaling factors."""
-    if not normalize and not resolved_weights:
-        return None
+    """
+    Full per-embedding-column scaling for a single Features object.
 
-    base_stds: dict[str, float] | None = None
-    if normalize:
-        col_sum: dict[str, float] = {}
-        col_sq: dict[str, float] = {}
-        col_n: dict[str, int] = {}
-        for _gkey, _fname, feat in _iter_features(fc):
-            for base_col in embedding_dict:
-                vals = feat.data[base_col].to_numpy(dtype=np.float64)
-                finite = vals[np.isfinite(vals)]
-                if base_col not in col_sum:
-                    col_sum[base_col] = 0.0
-                    col_sq[base_col] = 0.0
-                    col_n[base_col] = 0
-                col_sum[base_col] += finite.sum()
-                col_sq[base_col] += (finite**2).sum()
-                col_n[base_col] += len(finite)
-        base_stds = {}
-        for base_col in embedding_dict:
-            n = col_n[base_col]
-            if n == 0:
-                base_stds[base_col] = 1.0
-                continue
-            mean = col_sum[base_col] / n
-            std = float(np.sqrt(col_sq[base_col] / n - mean**2))
-            base_stds[base_col] = std if std > 0 else 1.0
+    For "individual" columns, the std is computed from *feat* itself.
+    For "global" columns, it uses pre-computed *global_base_stds*.
+    For "none" columns, no normalisation factor is applied.
+    Weights are always applied on top.
 
-    first_feat = next(_iter_features(fc))[2]
-    embed_cols = first_feat.embedding_df(embedding_dict).columns
-
+    Returns ``None`` when all factors are 1.0.
+    """
+    embed_cols = list(feat.embedding_df(embedding_dict).columns)
     factors: dict[str, float] = {}
     for col in embed_cols:
         base = _base_feature_for_column(col, embedding_dict)
-        norm_factor = 1.0 / base_stds[base] if base_stds is not None else 1.0
+        mode = resolved_norm.get(col, "none")
+        if mode == "none":
+            norm_f = 1.0
+        elif mode == "global":
+            denom = global_base_stds.get(base, 1.0)
+            norm_f = 1.0 / denom if denom > 0 else 1.0
+        elif mode == "individual":
+            norm_f = 1.0 / _safe_std(feat.data[base].to_numpy(dtype=np.float64))
+        else:
+            raise ValueError(f"Unknown normalisation mode: {mode!r}")
         weight = resolved_weights.get(col, 1.0) if resolved_weights else 1.0
-        factors[col] = norm_factor * weight
-
+        factors[col] = norm_f * weight
     has_non_unity = any(v != 1.0 for v in factors.values())
     return factors if has_non_unity else None
+
+
+def _constant_scaling_factors(
+    embed_cols: list[str] | pd.Index,
+    embedding_dict: dict[str, list[int]],
+    *,
+    resolved_norm: dict[str, Literal["individual", "global", "none"]],
+    resolved_weights: dict[str, float] | None,
+    global_base_stds: dict[str, float],
+) -> dict[str, float] | None:
+    """
+    Constant per-embedding-column multipliers: weights plus any global norm factors.
+
+    Individual-mode columns contribute only their weight (not their per-Features
+    std, which varies).  This is the ``scaling_factors`` third return value.
+
+    Returns ``None`` when all factors are 1.0.
+    """
+    factors: dict[str, float] = {}
+    for col in list(embed_cols):
+        base = _base_feature_for_column(col, embedding_dict)
+        mode = resolved_norm.get(col, "none")
+        if mode == "global":
+            denom = global_base_stds.get(base, 1.0)
+            norm_f = 1.0 / denom if denom > 0 else 1.0
+        else:
+            norm_f = 1.0
+        weight = resolved_weights.get(col, 1.0) if resolved_weights else 1.0
+        factors[col] = norm_f * weight
+    has_non_unity = any(v != 1.0 for v in factors.values())
+    return factors if has_non_unity else None
+
+
+def _build_scaling_recipe(
+    embedding_dict: dict[str, list[int]],
+    columns: list[str],
+    resolved_norm: dict[str, Literal["individual", "global", "none"]],
+    constant_factors: dict[str, float] | None,
+) -> dict:
+    """
+    Build the minimal scaling recipe stored inside a ``CentroidsDf``.
+
+    Parameters
+    ----------
+    embedding_dict :
+        The embedding used during clustering (for reproducing the embedding).
+    columns :
+        Actual embedding column names (sanity-check on load).
+    resolved_norm :
+        Per-column normalisation mode, already resolved from user rules.
+    constant_factors :
+        The ``scaling_factors`` constant multipliers (weights + global norms).
+    """
+    normalize_individual_base: dict[str, bool] = {}
+    for base in embedding_dict:
+        base_cols = [c for c in columns if c.startswith(base + "_t")]
+        normalize_individual_base[base] = any(
+            resolved_norm.get(c) == "individual" for c in base_cols
+        )
+    return {
+        "version": 1,
+        "embedding_dict": embedding_dict,
+        "columns": columns,
+        "normalize_individual_base": normalize_individual_base,
+        "constant_factors": {} if constant_factors is None else dict(constant_factors),
+    }
+
+
+def _apply_per_features_scaling(
+    combined: pd.DataFrame,
+    fc,
+    embedding_dict: dict[str, list[int]],
+    *,
+    resolved_norm: dict[str, Literal["individual", "global", "none"]],
+    resolved_weights: dict[str, float] | None,
+    global_base_stds: dict[str, float],
+    flat_key: str,
+) -> pd.DataFrame:
+    """
+    Apply per-Features (including individual) scaling to the combined DataFrame.
+
+    The combined DF is indexed by (group, feature, frame).  Each (group, feature)
+    slice gets its own scaling dict computed by ``_scaling_for_features``.
+    """
+    result = combined.copy()
+    for gkey, feat_name, feat in _iter_features(fc):
+        per_sf = _scaling_for_features(
+            feat,
+            embedding_dict,
+            resolved_norm=resolved_norm,
+            resolved_weights=resolved_weights,
+            global_base_stds=global_base_stds,
+        )
+        if per_sf is None:
+            continue
+        key0 = gkey if gkey is not None else flat_key
+        idx = pd.IndexSlice[key0, feat_name, :]
+        result.loc[idx, :] = result.loc[idx, :].mul(pd.Series(per_sf), axis=1).values
+    return result
 
 
 class StreamingClusteringPipeline:
     """
     Memory-friendly clustering via MiniBatchKMeans.partial_fit.
 
-    Phase 1 (optional): streaming pass to compute per-base-feature stds.
-    Phase 2: n_epochs passes of partial_fit over fixed-size chunks.
-    Phase 3: per-Features assignment using the fitted centroids.
+    Phase 1: Resolve normalisation modes and compute global stds where needed.
+    Phase 2: n_epochs passes of partial_fit over fixed-size chunks, one Features
+             at a time.  Per-Features scaling (including individual std) is applied
+             chunk-by-chunk.
+    Phase 3: Per-Features assignment using the fitted centroids.
 
-    Normalisation is computed on base feature columns (before embedding)
-    so all time-shifts of the same feature share the same std.
-
-    The returned scaling_factors dict contains one float per embedding
-    column — the combined effect of normalisation and column weights.
-    Multiply raw embedding columns by these values to reproduce the
-    transform.
+    The returned ``scaling_factors`` (third element) is a dict of constant
+    per-embedding-column multipliers — weights plus any global normalisation.
+    For columns using "individual" normalisation the per-Features std is *not*
+    included (it varies per recording); the ``CentroidsDf.scaling_recipe`` captures
+    this so it can be reproduced on future datasets.
     """
 
     def run(
@@ -491,15 +719,33 @@ class StreamingClusteringPipeline:
         embedding_dict: dict[str, list[int]],
         cfg: StreamingConfig,
     ) -> tuple[dict, pd.DataFrame, dict[str, float] | None, dict]:
-        resolved_weights = None
-        if cfg.feature_weights is not None:
-            first_feat = next(_iter_features(fc))[2]
-            first_cols = first_feat.embedding_df(embedding_dict).columns
-            resolved_weights = _resolve_feature_weights(first_cols, cfg.feature_weights)
+        first_feat = next(_iter_features(fc))[2]
+        embed_cols = list(first_feat.embedding_df(embedding_dict).columns)
 
-        base_stds = self._compute_base_stds(fc, embedding_dict, cfg) if cfg.normalize else None
-        scaling_factors, impute_means = self._build_scaling(
-            fc, embedding_dict, cfg, resolved_weights, base_stds
+        resolved_weights: dict[str, float] | None = None
+        if cfg.feature_weights is not None:
+            resolved_weights = _resolve_feature_weights(embed_cols, cfg.feature_weights)
+
+        default_mode: Literal["global", "none"] = "global" if cfg.normalize else "none"
+        resolved_norm = _resolve_column_modes(
+            embed_cols, cfg.normalize_details, default=default_mode
+        )
+
+        bases_needed = {
+            _base_feature_for_column(c, embedding_dict)
+            for c, m in resolved_norm.items()
+            if m == "global"
+        }
+        global_base_stds = _compute_global_base_stds(fc, embedding_dict, bases_needed=bases_needed)
+
+        constant_factors, impute_means = self._build_scaling(
+            fc,
+            embedding_dict,
+            cfg,
+            embed_cols=embed_cols,
+            resolved_weights=resolved_weights,
+            resolved_norm=resolved_norm,
+            global_base_stds=global_base_stds,
         )
 
         model = MiniBatchKMeans(
@@ -521,21 +767,28 @@ class StreamingClusteringPipeline:
                             f"expected {resolved_weights}, got {check}"
                         )
 
-                if scaling_factors is not None:
-                    embed_df = embed_df * pd.Series(scaling_factors)
+                per_sf = _scaling_for_features(
+                    feat,
+                    embedding_dict,
+                    resolved_norm=resolved_norm,
+                    resolved_weights=resolved_weights,
+                    global_base_stds=global_base_stds,
+                )
+                if per_sf is not None:
+                    embed_df = embed_df * pd.Series(per_sf)
                 columns = embed_df.columns
                 for start in range(0, len(embed_df), cfg.chunk_size):
                     chunk = embed_df.iloc[start : start + cfg.chunk_size]
-                    X, w = self._prepare_chunk(
-                        chunk,
-                        cfg.missing_policy,
-                        impute_means,
-                    )
+                    X, w = self._prepare_chunk(chunk, cfg.missing_policy, impute_means)
                     if len(X) == 0:
                         continue
                     model.partial_fit(X, sample_weight=w)
 
         centroids = pd.DataFrame(model.cluster_centers_, columns=columns)
+
+        scaling_recipe = _build_scaling_recipe(
+            embedding_dict, list(embed_cols), resolved_norm, constant_factors
+        )
 
         meta = {
             "function": "cluster_embedding_stream",
@@ -543,6 +796,7 @@ class StreamingClusteringPipeline:
             "n_clusters": cfg.n_clusters,
             "random_state": cfg.random_state,
             "normalize": cfg.normalize,
+            "normalize_details": cfg.normalize_details,
             "feature_weights": cfg.feature_weights,
             "resolved_feature_weights": resolved_weights,
             "missing_policy": cfg.missing_policy,
@@ -550,17 +804,20 @@ class StreamingClusteringPipeline:
             "n_epochs": cfg.n_epochs,
             "batch_size": cfg.batch_size,
             "impute_means": (impute_means.to_dict() if impute_means is not None else None),
+            "scaling_recipe": scaling_recipe,
         }
 
         result_dict = self._assign_all(
             fc,
             embedding_dict,
             centroids,
-            scaling_factors,
-            impute_means,
-            meta,
+            resolved_norm=resolved_norm,
+            resolved_weights=resolved_weights,
+            global_base_stds=global_base_stds,
+            impute_means=impute_means,
+            meta=meta,
         )
-        return result_dict, centroids, scaling_factors, meta
+        return result_dict, centroids, constant_factors, meta
 
     # -- internal helpers ---------------------------------------------------
 
@@ -573,81 +830,83 @@ class StreamingClusteringPipeline:
         return chunk[valid].values, None
 
     @staticmethod
-    def _compute_base_stds(fc, embedding_dict, cfg):
-        """Streaming pass over base feature columns to get per-feature stds."""
-        col_sum: dict[str, float] = {}
-        col_sq_sum: dict[str, float] = {}
-        col_n: dict[str, int] = {}
-        for _gkey, _fname, feat in _iter_features(fc):
-            for base_col in embedding_dict:
-                vals = feat.data[base_col].to_numpy(dtype=np.float64)
-                finite = vals[np.isfinite(vals)]
-                if base_col not in col_sum:
-                    col_sum[base_col] = 0.0
-                    col_sq_sum[base_col] = 0.0
-                    col_n[base_col] = 0
-                col_sum[base_col] += finite.sum()
-                col_sq_sum[base_col] += (finite**2).sum()
-                col_n[base_col] += len(finite)
-
-        base_stds: dict[str, float] = {}
-        for base_col in embedding_dict:
-            n = col_n[base_col]
-            if n == 0:
-                base_stds[base_col] = 1.0
-                continue
-            mean = col_sum[base_col] / n
-            std = np.sqrt(col_sq_sum[base_col] / n - mean**2)
-            base_stds[base_col] = std if std > 0 else 1.0
-        return base_stds
-
-    @staticmethod
-    def _build_scaling(fc, embedding_dict, cfg, resolved_weights, base_stds):
+    def _build_scaling(
+        fc,
+        embedding_dict: dict[str, list[int]],
+        cfg: StreamingConfig,
+        *,
+        embed_cols: list[str],
+        resolved_weights: dict[str, float] | None,
+        resolved_norm: dict[str, Literal["individual", "global", "none"]],
+        global_base_stds: dict[str, float],
+    ) -> tuple[dict[str, float] | None, pd.Series | None]:
         """
-        Build the combined per-embedding-column scaling factors and impute means.
+        Compute constant scaling factors and (optionally) imputation means.
 
-        Each factor is: (1 / base_std if normalize else 1) * (column_weight or 1).
-        Multiply raw embedding columns by these to reproduce the transform.
+        The constant factors are weights plus any global normalisation — they
+        do not include per-Features individual std (that is applied at fit/assign
+        time via ``_scaling_for_features``).
         """
-        first_feat = next(_iter_features(fc))[2]
-        embed_cols = first_feat.embedding_df(embedding_dict).columns
+        constant_factors = _constant_scaling_factors(
+            embed_cols,
+            embedding_dict,
+            resolved_norm=resolved_norm,
+            resolved_weights=resolved_weights,
+            global_base_stds=global_base_stds,
+        )
 
-        factors: dict[str, float] = {}
-        for col in embed_cols:
-            base = _base_feature_for_column(col, embedding_dict)
-            norm_factor = 1.0 / base_stds[base] if base_stds is not None else 1.0
-            weight = resolved_weights.get(col, 1.0) if resolved_weights else 1.0
-            factors[col] = norm_factor * weight
-
-        has_non_unity = any(v != 1.0 for v in factors.values())
-        scaling_factors = factors if has_non_unity else None
-
-        impute_means = None
+        impute_means: pd.Series | None = None
         if cfg.missing_policy == "impute_weight":
-            # Streaming means on the scaled embedding
             col_sum = np.zeros(len(embed_cols), dtype=np.float64)
             n_valid = 0
-            scale_arr = np.array([factors[c] for c in embed_cols], dtype=np.float64)
             for _gkey, _fname, feat in _iter_features(fc):
                 embed_df = feat.embedding_df(embedding_dict).astype(np.float32)
-                vals = embed_df.values * scale_arr
+                per_sf = _scaling_for_features(
+                    feat,
+                    embedding_dict,
+                    resolved_norm=resolved_norm,
+                    resolved_weights=resolved_weights,
+                    global_base_stds=global_base_stds,
+                )
+                if per_sf is not None:
+                    scale_arr = np.array([per_sf[c] for c in embed_cols], dtype=np.float64)
+                    vals = embed_df.values * scale_arr
+                else:
+                    vals = embed_df.values.astype(np.float64)
                 row_valid = np.isfinite(vals).all(axis=1)
                 col_sum += vals[row_valid].sum(axis=0)
-                n_valid += row_valid.sum()
+                n_valid += int(row_valid.sum())
             if n_valid > 0:
                 impute_means = pd.Series(col_sum / n_valid, index=embed_cols)
 
-        return scaling_factors, impute_means
+        return constant_factors, impute_means
 
     @staticmethod
-    def _assign_all(fc, embedding_dict, centroids, scaling_factors, impute_means, meta):
+    def _assign_all(
+        fc,
+        embedding_dict: dict[str, list[int]],
+        centroids: pd.DataFrame,
+        *,
+        resolved_norm: dict[str, Literal["individual", "global", "none"]],
+        resolved_weights: dict[str, float] | None,
+        global_base_stds: dict[str, float],
+        impute_means: pd.Series | None,
+        meta: dict,
+    ) -> dict:
         is_grouped = getattr(fc, "is_grouped", False)
-        result_dict = {}
+        result_dict: dict = {}
         for gkey, feat_name, feat in _iter_features(fc):
+            per_sf = _scaling_for_features(
+                feat,
+                embedding_dict,
+                resolved_norm=resolved_norm,
+                resolved_weights=resolved_weights,
+                global_base_stds=global_base_stds,
+            )
             fr = feat.assign_clusters_by_centroids(
                 embedding_dict,
                 centroids,
-                scaling_factors=scaling_factors,
+                scaling_factors=per_sf,
                 impute_medians=impute_means,
             )
             if is_grouped:

--- a/src/py3r/behaviour/features/cluster_pipeline.py
+++ b/src/py3r/behaviour/features/cluster_pipeline.py
@@ -1,82 +1,20 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, NamedTuple, Protocol
+from typing import Literal, Protocol
 
 import numpy as np
 import pandas as pd
-from sklearn.cluster import KMeans, MiniBatchKMeans
+from sklearn.cluster import MiniBatchKMeans
 
 from py3r.behaviour.features.centroids_df import CentroidsDf
-from py3r.behaviour.features.features import Features, FeaturesResult
-from py3r.behaviour.util.missing_tolerance import fit_frame_imputer, impute_frame
-from py3r.behaviour.util.series_utils import (
-    apply_custom_scaling,
-    apply_normalization_to_df,
-    build_column_weights,
-    normalize_df,
-)
+from py3r.behaviour.features.features import Features
+from py3r.behaviour.util.missing_tolerance import impute_frame
+from py3r.behaviour.util.series_utils import build_column_weights
 
-
-class BuildResult(NamedTuple):
-    combined: pd.DataFrame
-    is_grouped: bool
-    flat_group_key: str
-    key_to_feature: dict[tuple[str, str], Features]
-
-
-class Preprocessor(Protocol):
-    def build(
-        self,
-        fc,
-        embedding_dict: dict[str, list[int]],
-        *,
-        lowmem: bool,
-        decimation_factor: int,
-    ) -> BuildResult: ...
-
-    def scale(
-        self,
-        df: pd.DataFrame,
-        *,
-        auto_normalize: bool,
-        rescale_factors: dict | None,
-        custom_scaling: dict[str, dict] | None,
-    ) -> tuple[pd.DataFrame, dict | None]: ...
-
-
-class MissingPolicy(Protocol):
-    def prepare(
-        self, df: pd.DataFrame, policy: Literal["drop", "impute_weight"]
-    ) -> tuple[pd.DataFrame, pd.Series | None, pd.Series | None, pd.Series]: ...
-
-
-class Clusterer(Protocol):
-    def fit(
-        self,
-        X: pd.DataFrame,
-        *,
-        sample_weight: pd.Series | None,
-        n_clusters: int,
-        random_state: int,
-    ) -> tuple[object, pd.DataFrame]: ...
-
-
-class Assigner(Protocol):
-    def assign_lowmem(
-        self,
-        fc,
-        centroids_obj: CentroidsDf,
-    ) -> dict: ...
-
-    def combined_labels(
-        self,
-        combined: pd.DataFrame,
-        model,
-        *,
-        valid_mask: pd.Series,
-        missing_policy: Literal["drop", "impute_weight"],
-    ) -> pd.Series: ...
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
 
 
 @dataclass(frozen=True)
@@ -86,148 +24,59 @@ class ClusteringConfig:
     normalize: bool = False
     normalize_details: dict[str, Literal["individual", "global", "none"]] | None = None
     feature_weights: dict[str, float] | None = None
-    auto_normalize: bool = False
-    rescale_factors: dict | None = None
-    lowmem: bool = False
-    decimation_factor: int = 10
-    custom_scaling: dict[str, dict] | None = None
     missing_policy: Literal["drop", "impute_weight"] = "drop"
+    chunk_size: int = 10_000
+    n_epochs: int = 3
+    batch_size: int = 1024
 
 
-class DefaultPreprocessor:
-    def build(
-        self,
-        fc,
-        embedding_dict: dict[str, list[int]],
-        *,
-        lowmem: bool,
-        decimation_factor: int,
-    ) -> BuildResult:
-        is_grouped = getattr(fc, "is_grouped", False)
-        flat_group_key = "__flat__"
-        group_iter = fc.items() if is_grouped else [(flat_group_key, fc)]
-        all_embeddings: dict[tuple[str, str], pd.DataFrame] = {}
-        key_to_feature: dict[tuple[str, str], Features] = {}
-        for gkey, sub in group_iter:
-            for feat_name, features in sub.features_dict.items():
-                embed_df = features.embedding_df(embedding_dict).astype(np.float32)
-                if lowmem:
-                    embed_df = embed_df.iloc[::decimation_factor]
-                key = (gkey, feat_name)
-                all_embeddings[key] = embed_df
-                key_to_feature[key] = features
-        combined = pd.concat(
-            all_embeddings.values(),
-            keys=all_embeddings.keys(),
-            names=["group", "feature", "frame"],
-        )
-        return BuildResult(combined, is_grouped, flat_group_key, key_to_feature)
-
-    def scale(
-        self,
-        df: pd.DataFrame,
-        *,
-        auto_normalize: bool,
-        rescale_factors: dict | None,
-        custom_scaling: dict[str, dict] | None,
-    ) -> tuple[pd.DataFrame, dict | None]:
-        if custom_scaling is not None and (auto_normalize or rescale_factors is not None):
-            raise ValueError(
-                "custom_scaling is mutually exclusive with auto_normalize or rescale_factors"
-            )
-        normalization_factors = None
-        if auto_normalize:
-            df, normalization_factors = normalize_df(df)
-        elif rescale_factors is not None:
-            df = apply_normalization_to_df(df, rescale_factors)
-        elif custom_scaling is not None:
-            df = apply_custom_scaling(df, custom_scaling)
-        return df, normalization_factors
+# ---------------------------------------------------------------------------
+# Injection seams (for testing)
+# ---------------------------------------------------------------------------
 
 
-class DefaultMissingPolicy:
-    def prepare(
-        self, df: pd.DataFrame, policy: Literal["drop", "impute_weight"]
-    ) -> tuple[pd.DataFrame, pd.Series | None, pd.Series | None, pd.Series]:
-        if policy == "impute_weight":
-            medians = fit_frame_imputer(df)
-            X_imp, sample_w = impute_frame(df, medians)
-            valid_mask = pd.Series(True, index=df.index)
-            return X_imp, sample_w, medians, valid_mask
-        else:
-            valid_mask = df.notna().all(axis=1)
-            X = df[valid_mask]
-            return X, None, None, valid_mask
-
-
-class KMeansClusterer:
-    def fit(
-        self,
-        X: pd.DataFrame,
-        *,
-        sample_weight: pd.Series | None,
-        n_clusters: int,
-        random_state: int,
-    ) -> tuple[object, pd.DataFrame]:
-        model = KMeans(n_clusters=n_clusters, random_state=random_state).fit(
-            X, sample_weight=None if sample_weight is None else sample_weight.values
-        )
-        centroids = pd.DataFrame(model.cluster_centers_, columns=X.columns)
-        return model, centroids
+class Assigner(Protocol):
+    def assign_all(self, fc, centroids: CentroidsDf) -> dict: ...
 
 
 class DefaultAssigner:
-    def assign_lowmem(
-        self,
-        fc,
-        centroids_obj: CentroidsDf,
-    ) -> dict:
+    def assign_all(self, fc, centroids: CentroidsDf) -> dict:
         is_grouped = getattr(fc, "is_grouped", False)
-        result_dict = {}
-        items = (
-            (
-                (gkey, feat_name, feat)
-                for gkey, sub in fc.items()
-                for feat_name, feat in sub.features_dict.items()
-            )
-            if is_grouped
-            else ((None, fn, f) for fn, f in fc.features_dict.items())
-        )
-        for gkey, feat_name, feat in items:
-            # impute_medians is read automatically from centroids_obj.scaling_recipe
-            fr = feat.assign_clusters_by_centroids(centroids_obj)
+        result_dict: dict = {}
+        for gkey, feat_name, feat in _iter_features(fc):
+            # impute_medians is read automatically from centroids.scaling_recipe
+            fr = feat.assign_clusters_by_centroids(centroids)
             if is_grouped:
                 result_dict.setdefault(gkey, {})[feat_name] = fr
             else:
                 result_dict[feat_name] = fr
         return result_dict
 
-    def combined_labels(
-        self,
-        combined: pd.DataFrame,
-        model,
-        *,
-        valid_mask: pd.Series,
-        missing_policy: Literal["drop", "impute_weight"],
-    ) -> pd.Series:
-        if missing_policy == "impute_weight":
-            return pd.Series(model.labels_, index=combined.index)
-        labels = pd.Series(np.nan, index=combined.index)
-        labels.loc[valid_mask] = model.labels_
-        return labels
+
+# ---------------------------------------------------------------------------
+# Pipeline
+# ---------------------------------------------------------------------------
 
 
 class ClusteringPipeline:
-    def __init__(
-        self,
-        pre: Preprocessor | None = None,
-        missing: MissingPolicy | None = None,
-        clusterer: Clusterer | None = None,
-        assigner: Assigner | None = None,
-    ):
-        self.pre = pre or DefaultPreprocessor()
-        self.missing = missing or DefaultMissingPolicy()
-        self.clusterer = clusterer or KMeansClusterer()
+    """
+    Memory-friendly clustering via MiniBatchKMeans.partial_fit.
+
+    Phases
+    ------
+    1. Resolve normalisation modes and validate feature weights.
+    2. Compute global stds (if any column uses "global" normalisation).
+    3. Compute imputation means (if missing_policy="impute_weight").
+    4. n_epochs passes of partial_fit, one Features at a time, chunk by chunk.
+    5. Per-Features assignment using the fitted centroids.
+
+    The ``CentroidsDf`` returned as the second element of the result tuple
+    carries a ``scaling_recipe`` with everything needed to reproduce the
+    transform on future datasets (embedding, per-column norm flags, constant
+    factors, and imputation means).
+    """
+
+    def __init__(self, assigner: Assigner | None = None):
         self.assigner = assigner or DefaultAssigner()
 
     def run(
@@ -235,102 +84,81 @@ class ClusteringPipeline:
         fc,
         embedding_dict: dict[str, list[int]],
         cfg: ClusteringConfig,
-    ) -> tuple[dict, pd.DataFrame, dict | None, dict]:
-        if cfg.auto_normalize:
-            raise NotImplementedError("auto_normalize was removed; use normalize=True instead.")
-        if cfg.rescale_factors is not None:
-            raise NotImplementedError(
-                "rescale_factors was removed; use normalize and/or feature_weights instead."
-            )
-        if cfg.custom_scaling is not None:
-            raise NotImplementedError("custom_scaling was removed; use feature_weights instead.")
-
-        build = self.pre.build(
-            fc,
-            embedding_dict,
-            lowmem=cfg.lowmem,
-            decimation_factor=cfg.decimation_factor,
-        )
-
-        using_new = (
-            cfg.normalize or cfg.feature_weights is not None or cfg.normalize_details is not None
-        )
+    ) -> tuple[dict, CentroidsDf, dict[str, float] | None, dict]:
+        # -- Phase 1: resolve scaling -------------------------------------------
+        first_feat = next(_iter_features(fc))[2]
+        embed_cols = list(first_feat.embedding_df(embedding_dict).columns)
 
         resolved_weights: dict[str, float] | None = None
-        resolved_norm: dict[str, Literal["individual", "global", "none"]] = {}
-        global_base_stds: dict[str, float] = {}
+        if cfg.feature_weights is not None:
+            resolved_weights = _resolve_feature_weights(embed_cols, cfg.feature_weights)
+            _validate_weights_consistent(fc, embedding_dict, resolved_weights)
 
-        if using_new:
-            first_feat = next(_iter_features(fc))[2]
-            embed_cols = list(first_feat.embedding_df(embedding_dict).columns)
+        default_mode: Literal["global", "none"] = "global" if cfg.normalize else "none"
+        resolved_norm = _resolve_column_modes(
+            embed_cols, cfg.normalize_details, default=default_mode
+        )
 
-            if cfg.feature_weights is not None:
-                resolved_weights = _resolve_feature_weights(embed_cols, cfg.feature_weights)
+        # -- Phase 2: global stds -----------------------------------------------
+        bases_needed = {
+            _base_feature_for_column(c, embedding_dict)
+            for c, m in resolved_norm.items()
+            if m == "global"
+        }
+        global_base_stds = _compute_global_base_stds(fc, embedding_dict, bases_needed=bases_needed)
 
-            default_mode: Literal["global", "none"] = "global" if cfg.normalize else "none"
-            resolved_norm = _resolve_column_modes(
-                embed_cols, cfg.normalize_details, default=default_mode
-            )
+        constant_factors = _constant_scaling_factors(
+            embed_cols,
+            embedding_dict,
+            resolved_norm=resolved_norm,
+            resolved_weights=resolved_weights,
+            global_base_stds=global_base_stds,
+        )
 
-            bases_needed = {
-                _base_feature_for_column(c, embedding_dict)
-                for c, m in resolved_norm.items()
-                if m == "global"
-            }
-            global_base_stds = _compute_global_base_stds(
-                fc, embedding_dict, bases_needed=bases_needed
-            )
+        # -- Phase 3: imputation means ------------------------------------------
+        impute_means = _compute_impute_means(
+            fc,
+            embedding_dict,
+            cfg,
+            embed_cols=embed_cols,
+            resolved_norm=resolved_norm,
+            resolved_weights=resolved_weights,
+            global_base_stds=global_base_stds,
+        )
 
-            constant_factors = _constant_scaling_factors(
-                embed_cols,
-                embedding_dict,
-                resolved_norm=resolved_norm,
-                resolved_weights=resolved_weights,
-                global_base_stds=global_base_stds,
-            )
-            norm = constant_factors
+        # -- Phase 4: train -----------------------------------------------------
+        model = MiniBatchKMeans(
+            n_clusters=cfg.n_clusters,
+            random_state=cfg.random_state,
+            batch_size=cfg.batch_size,
+        )
 
-            has_individual = any(m == "individual" for m in resolved_norm.values())
-            if has_individual:
-                combined = _apply_per_features_scaling(
-                    build.combined,
-                    fc,
+        columns = None
+        for _epoch in range(cfg.n_epochs):
+            for _gkey, _fname, feat in _iter_features(fc):
+                embed_df = feat.embedding_df(embedding_dict).astype(np.float32)
+                per_sf = _scaling_for_features(
+                    feat,
                     embedding_dict,
                     resolved_norm=resolved_norm,
                     resolved_weights=resolved_weights,
                     global_base_stds=global_base_stds,
-                    flat_key=build.flat_group_key,
                 )
-            else:
-                combined = build.combined
-                if constant_factors is not None:
-                    combined = combined * pd.Series(constant_factors)
+                if per_sf is not None:
+                    embed_df = embed_df * pd.Series(per_sf)
+                columns = embed_df.columns
+                for start in range(0, len(embed_df), cfg.chunk_size):
+                    chunk = embed_df.iloc[start : start + cfg.chunk_size]
+                    X, w = _prepare_chunk(chunk, cfg.missing_policy, impute_means)
+                    if len(X) == 0:
+                        continue
+                    model.partial_fit(X, sample_weight=w)
 
-        else:
-            combined, norm = self.pre.scale(
-                build.combined,
-                auto_normalize=cfg.auto_normalize,
-                rescale_factors=cfg.rescale_factors,
-                custom_scaling=cfg.custom_scaling,
-            )
-            first_feat = next(_iter_features(fc))[2]
-            embed_cols = list(first_feat.embedding_df(embedding_dict).columns)
-            resolved_norm = {c: "none" for c in embed_cols}
-
-        X, w, impute_medians, valid_mask = self.missing.prepare(combined, cfg.missing_policy)
-        model, centroids_df = self.clusterer.fit(
-            X, sample_weight=w, n_clusters=cfg.n_clusters, random_state=cfg.random_state
+        # -- Phase 5: build centroids and assign --------------------------------
+        centroids_df = pd.DataFrame(model.cluster_centers_, columns=columns)
+        scaling_recipe = _build_scaling_recipe(
+            embedding_dict, list(embed_cols), resolved_norm, constant_factors, impute_means
         )
-
-        # Build recipe after impute_medians is known (it depends on missing_policy).
-        if using_new:
-            scaling_recipe = _build_scaling_recipe(
-                embedding_dict, embed_cols, resolved_norm, constant_factors, impute_medians
-            )
-        else:
-            scaling_recipe = _build_scaling_recipe(
-                embedding_dict, embed_cols, resolved_norm, norm, impute_medians
-            )
         centroids = CentroidsDf(df=centroids_df, scaling_recipe=scaling_recipe)
 
         meta = {
@@ -341,62 +169,21 @@ class ClusteringPipeline:
             "normalize_details": cfg.normalize_details,
             "feature_weights": cfg.feature_weights,
             "resolved_feature_weights": resolved_weights,
-            "auto_normalize": cfg.auto_normalize,
-            "rescale_factors": cfg.rescale_factors,
-            "lowmem": cfg.lowmem,
-            "decimation_factor": cfg.decimation_factor,
             "missing_policy": cfg.missing_policy,
-            "impute_medians": None if impute_medians is None else impute_medians.to_dict(),
+            "chunk_size": cfg.chunk_size,
+            "n_epochs": cfg.n_epochs,
+            "batch_size": cfg.batch_size,
+            "impute_means": (impute_means.to_dict() if impute_means is not None else None),
             "scaling_recipe": scaling_recipe,
         }
 
-        if cfg.lowmem:
-            # impute_medians is embedded in centroids.scaling_recipe
-            result_dict = self.assigner.assign_lowmem(fc, centroids)
-            return result_dict, centroids, norm, meta
-
-        # Non-lowmem: reconstruct per-feature FeaturesResult from combined_labels
-        combined_labels = self.assigner.combined_labels(
-            combined, model, valid_mask=valid_mask, missing_policy=cfg.missing_policy
-        )
-        if build.is_grouped:
-            result_dict = {}
-            for (gkey, feat_name), feat in build.key_to_feature.items():
-                labels = combined_labels.xs((gkey, feat_name), level=["group", "feature"]).astype(
-                    "Int64"
-                )
-                result_dict.setdefault(gkey, {})[feat_name] = FeaturesResult(
-                    labels, feat, f"kmeans_{cfg.n_clusters}", meta
-                )
-        else:
-            result_dict = {}
-            flat = build.flat_group_key
-            for (_, feat_name), feat in build.key_to_feature.items():
-                labels = combined_labels.xs((flat, feat_name), level=["group", "feature"]).astype(
-                    "Int64"
-                )
-                result_dict[feat_name] = FeaturesResult(
-                    labels, feat, f"kmeans_{cfg.n_clusters}", meta
-                )
-        return result_dict, centroids, norm, meta
+        result_dict = self.assigner.assign_all(fc, centroids)
+        return result_dict, centroids, constant_factors, meta
 
 
 # ---------------------------------------------------------------------------
-# Streaming (MiniBatchKMeans + partial_fit) pipeline
+# Module-level helpers
 # ---------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class StreamingConfig:
-    n_clusters: int
-    random_state: int = 0
-    normalize: bool = False
-    normalize_details: dict[str, Literal["individual", "global", "none"]] | None = None
-    feature_weights: dict[str, float] | None = None
-    missing_policy: Literal["drop", "impute_weight"] = "drop"
-    chunk_size: int = 10_000
-    n_epochs: int = 3
-    batch_size: int = 1024
 
 
 def _iter_features(fc):
@@ -418,22 +205,36 @@ def _resolve_feature_weights(
     """
     Resolve substring *feature_weights* into per-column weights and print the mapping.
 
-    *columns* must be the real embedding column names obtained from
-    ``feat.embedding_df(embedding_dict).columns``.
-
     Raises ValueError (via build_column_weights) if any rule matches no column
     or any column matches multiple rules.
     """
     weights = build_column_weights(columns, feature_weights)
-
     for rule, w in feature_weights.items():
         matched = [c for c in columns if rule in c]
         print(f"  feature_weights: {rule!r} → {matched} × {w:.4g}")
     unmatched = [c for c in columns if weights[c] == 1.0]
     if unmatched:
         print(f"  feature_weights: unmatched columns (weight 1.0): {unmatched}")
-
     return weights
+
+
+def _validate_weights_consistent(
+    fc,
+    embedding_dict: dict[str, list[int]],
+    resolved_weights: dict[str, float],
+) -> None:
+    """
+    Verify that every Features in the collection produces the same embedding
+    column set as the first one (on which *resolved_weights* was computed).
+    Raises ValueError on the first mismatch.
+    """
+    for _gkey, fname, feat in _iter_features(fc):
+        cols = set(feat.embedding_df(embedding_dict).columns)
+        if cols != set(resolved_weights):
+            raise ValueError(
+                f"Embedding columns differ for '{fname}': "
+                f"expected {set(resolved_weights)}, got {cols}"
+            )
 
 
 def _base_feature_for_column(col: str, embedding_dict: dict[str, list[int]]) -> str:
@@ -442,11 +243,6 @@ def _base_feature_for_column(col: str, embedding_dict: dict[str, list[int]]) -> 
         if col.startswith(base + "_t"):
             return base
     raise ValueError(f"Cannot determine base feature for embedding column '{col}'")
-
-
-# ---------------------------------------------------------------------------
-# Normalisation helpers
-# ---------------------------------------------------------------------------
 
 
 def _resolve_column_modes(
@@ -539,9 +335,8 @@ def _scaling_for_features(
     """
     Full per-embedding-column scaling for a single Features object.
 
-    For "individual" columns, the std is computed from *feat* itself.
-    For "global" columns, it uses pre-computed *global_base_stds*.
-    For "none" columns, no normalisation factor is applied.
+    For "individual" columns the std is computed from *feat* itself.
+    For "global" columns *global_base_stds* is used.
     Weights are always applied on top.
 
     Returns ``None`` when all factors are 1.0.
@@ -575,7 +370,7 @@ def _constant_scaling_factors(
     global_base_stds: dict[str, float],
 ) -> dict[str, float] | None:
     """
-    Constant per-embedding-column multipliers: weights plus any global norm factors.
+    Constant per-embedding-column multipliers: weights plus global norm factors.
 
     Individual-mode columns contribute only their weight (not their per-Features
     std, which varies).  This is the ``scaling_factors`` third return value.
@@ -616,12 +411,11 @@ def _build_scaling_recipe(
     resolved_norm :
         Per-column normalisation mode, already resolved from user rules.
     constant_factors :
-        The ``scaling_factors`` constant multipliers (weights + global norms).
+        Constant multipliers (weights + global norms).
     impute_medians :
         Per-column fill values used during training when
-        ``missing_policy="impute_weight"``.  Stored so future calls to
-        ``assign_clusters_by_centroids`` can reproduce the same imputation.
-        ``None`` when ``missing_policy="drop"``.
+        ``missing_policy="impute_weight"``.  ``None`` when
+        ``missing_policy="drop"``.
     """
     normalize_individual_base: dict[str, bool] = {}
     for base in embedding_dict:
@@ -639,24 +433,26 @@ def _build_scaling_recipe(
     }
 
 
-def _apply_per_features_scaling(
-    combined: pd.DataFrame,
+def _compute_impute_means(
     fc,
     embedding_dict: dict[str, list[int]],
+    cfg: ClusteringConfig,
     *,
+    embed_cols: list[str],
     resolved_norm: dict[str, Literal["individual", "global", "none"]],
     resolved_weights: dict[str, float] | None,
     global_base_stds: dict[str, float],
-    flat_key: str,
-) -> pd.DataFrame:
+) -> pd.Series | None:
     """
-    Apply per-Features (including individual) scaling to the combined DataFrame.
-
-    The combined DF is indexed by (group, feature, frame).  Each (group, feature)
-    slice gets its own scaling dict computed by ``_scaling_for_features``.
+    Compute per-column imputation means from the (scaled) embedding across the
+    whole collection.  Returns ``None`` when ``missing_policy="drop"``.
     """
-    result = combined.copy()
-    for gkey, feat_name, feat in _iter_features(fc):
+    if cfg.missing_policy != "impute_weight":
+        return None
+    col_sum = np.zeros(len(embed_cols), dtype=np.float64)
+    n_valid = 0
+    for _gkey, _fname, feat in _iter_features(fc):
+        embed_df = feat.embedding_df(embedding_dict).astype(np.float32)
         per_sf = _scaling_for_features(
             feat,
             embedding_dict,
@@ -664,204 +460,26 @@ def _apply_per_features_scaling(
             resolved_weights=resolved_weights,
             global_base_stds=global_base_stds,
         )
-        if per_sf is None:
-            continue
-        key0 = gkey if gkey is not None else flat_key
-        idx = pd.IndexSlice[key0, feat_name, :]
-        result.loc[idx, :] = result.loc[idx, :].mul(pd.Series(per_sf), axis=1).values
-    return result
+        if per_sf is not None:
+            scale_arr = np.array([per_sf[c] for c in embed_cols], dtype=np.float64)
+            vals = embed_df.values * scale_arr
+        else:
+            vals = embed_df.values.astype(np.float64)
+        row_valid = np.isfinite(vals).all(axis=1)
+        col_sum += vals[row_valid].sum(axis=0)
+        n_valid += int(row_valid.sum())
+    if n_valid > 0:
+        return pd.Series(col_sum / n_valid, index=embed_cols)
+    return None
 
 
-class StreamingClusteringPipeline:
-    """
-    Memory-friendly clustering via MiniBatchKMeans.partial_fit.
-
-    Phase 1: Resolve normalisation modes and compute global stds where needed.
-    Phase 2: n_epochs passes of partial_fit over fixed-size chunks, one Features
-             at a time.  Per-Features scaling (including individual std) is applied
-             chunk-by-chunk.
-    Phase 3: Per-Features assignment using the fitted centroids.
-
-    The returned ``scaling_factors`` (third element) is a dict of constant
-    per-embedding-column multipliers — weights plus any global normalisation.
-    For columns using "individual" normalisation the per-Features std is *not*
-    included (it varies per recording); the ``CentroidsDf.scaling_recipe`` captures
-    this so it can be reproduced on future datasets.
-    """
-
-    def run(
-        self,
-        fc,
-        embedding_dict: dict[str, list[int]],
-        cfg: StreamingConfig,
-    ) -> tuple[dict, pd.DataFrame, dict[str, float] | None, dict]:
-        first_feat = next(_iter_features(fc))[2]
-        embed_cols = list(first_feat.embedding_df(embedding_dict).columns)
-
-        resolved_weights: dict[str, float] | None = None
-        if cfg.feature_weights is not None:
-            resolved_weights = _resolve_feature_weights(embed_cols, cfg.feature_weights)
-
-        default_mode: Literal["global", "none"] = "global" if cfg.normalize else "none"
-        resolved_norm = _resolve_column_modes(
-            embed_cols, cfg.normalize_details, default=default_mode
-        )
-
-        bases_needed = {
-            _base_feature_for_column(c, embedding_dict)
-            for c, m in resolved_norm.items()
-            if m == "global"
-        }
-        global_base_stds = _compute_global_base_stds(fc, embedding_dict, bases_needed=bases_needed)
-
-        constant_factors, impute_means = self._build_scaling(
-            fc,
-            embedding_dict,
-            cfg,
-            embed_cols=embed_cols,
-            resolved_weights=resolved_weights,
-            resolved_norm=resolved_norm,
-            global_base_stds=global_base_stds,
-        )
-
-        model = MiniBatchKMeans(
-            n_clusters=cfg.n_clusters,
-            random_state=cfg.random_state,
-            batch_size=cfg.batch_size,
-        )
-
-        columns = None
-        for _epoch in range(cfg.n_epochs):
-            for _gkey, _fname, feat in _iter_features(fc):
-                embed_df = feat.embedding_df(embedding_dict).astype(np.float32)
-
-                if cfg.feature_weights is not None and _epoch == 0:
-                    check = build_column_weights(embed_df.columns, cfg.feature_weights)
-                    if check != resolved_weights:
-                        raise ValueError(
-                            f"feature_weights resolved differently for '{_fname}': "
-                            f"expected {resolved_weights}, got {check}"
-                        )
-
-                per_sf = _scaling_for_features(
-                    feat,
-                    embedding_dict,
-                    resolved_norm=resolved_norm,
-                    resolved_weights=resolved_weights,
-                    global_base_stds=global_base_stds,
-                )
-                if per_sf is not None:
-                    embed_df = embed_df * pd.Series(per_sf)
-                columns = embed_df.columns
-                for start in range(0, len(embed_df), cfg.chunk_size):
-                    chunk = embed_df.iloc[start : start + cfg.chunk_size]
-                    X, w = self._prepare_chunk(chunk, cfg.missing_policy, impute_means)
-                    if len(X) == 0:
-                        continue
-                    model.partial_fit(X, sample_weight=w)
-
-        centroids_df = pd.DataFrame(model.cluster_centers_, columns=columns)
-        scaling_recipe = _build_scaling_recipe(
-            embedding_dict, list(embed_cols), resolved_norm, constant_factors, impute_means
-        )
-        centroids = CentroidsDf(df=centroids_df, scaling_recipe=scaling_recipe)
-
-        meta = {
-            "function": "cluster_embedding_stream",
-            "embedding_dict": embedding_dict,
-            "n_clusters": cfg.n_clusters,
-            "random_state": cfg.random_state,
-            "normalize": cfg.normalize,
-            "normalize_details": cfg.normalize_details,
-            "feature_weights": cfg.feature_weights,
-            "resolved_feature_weights": resolved_weights,
-            "missing_policy": cfg.missing_policy,
-            "chunk_size": cfg.chunk_size,
-            "n_epochs": cfg.n_epochs,
-            "batch_size": cfg.batch_size,
-            "impute_means": (impute_means.to_dict() if impute_means is not None else None),
-            "scaling_recipe": scaling_recipe,
-        }
-
-        result_dict = self._assign_all(fc, centroids, meta=meta)
-        return result_dict, centroids, constant_factors, meta
-
-    # -- internal helpers ---------------------------------------------------
-
-    @staticmethod
-    def _prepare_chunk(chunk, missing_policy, impute_means):
-        if missing_policy == "impute_weight" and impute_means is not None:
-            X, w = impute_frame(chunk, impute_means)
-            return X.values, w.values
-        valid = chunk.notna().all(axis=1)
-        return chunk[valid].values, None
-
-    @staticmethod
-    def _build_scaling(
-        fc,
-        embedding_dict: dict[str, list[int]],
-        cfg: StreamingConfig,
-        *,
-        embed_cols: list[str],
-        resolved_weights: dict[str, float] | None,
-        resolved_norm: dict[str, Literal["individual", "global", "none"]],
-        global_base_stds: dict[str, float],
-    ) -> tuple[dict[str, float] | None, pd.Series | None]:
-        """
-        Compute constant scaling factors and (optionally) imputation means.
-
-        The constant factors are weights plus any global normalisation — they
-        do not include per-Features individual std (that is applied at fit/assign
-        time via ``_scaling_for_features``).
-        """
-        constant_factors = _constant_scaling_factors(
-            embed_cols,
-            embedding_dict,
-            resolved_norm=resolved_norm,
-            resolved_weights=resolved_weights,
-            global_base_stds=global_base_stds,
-        )
-
-        impute_means: pd.Series | None = None
-        if cfg.missing_policy == "impute_weight":
-            col_sum = np.zeros(len(embed_cols), dtype=np.float64)
-            n_valid = 0
-            for _gkey, _fname, feat in _iter_features(fc):
-                embed_df = feat.embedding_df(embedding_dict).astype(np.float32)
-                per_sf = _scaling_for_features(
-                    feat,
-                    embedding_dict,
-                    resolved_norm=resolved_norm,
-                    resolved_weights=resolved_weights,
-                    global_base_stds=global_base_stds,
-                )
-                if per_sf is not None:
-                    scale_arr = np.array([per_sf[c] for c in embed_cols], dtype=np.float64)
-                    vals = embed_df.values * scale_arr
-                else:
-                    vals = embed_df.values.astype(np.float64)
-                row_valid = np.isfinite(vals).all(axis=1)
-                col_sum += vals[row_valid].sum(axis=0)
-                n_valid += int(row_valid.sum())
-            if n_valid > 0:
-                impute_means = pd.Series(col_sum / n_valid, index=embed_cols)
-
-        return constant_factors, impute_means
-
-    @staticmethod
-    def _assign_all(
-        fc,
-        centroids: CentroidsDf,
-        *,
-        meta: dict,
-    ) -> dict:
-        is_grouped = getattr(fc, "is_grouped", False)
-        result_dict: dict = {}
-        for gkey, feat_name, feat in _iter_features(fc):
-            # impute_medians is read automatically from centroids.scaling_recipe
-            fr = feat.assign_clusters_by_centroids(centroids)
-            if is_grouped:
-                result_dict.setdefault(gkey, {})[feat_name] = fr
-            else:
-                result_dict[feat_name] = fr
-        return result_dict
+def _prepare_chunk(
+    chunk: pd.DataFrame,
+    missing_policy: Literal["drop", "impute_weight"],
+    impute_means: pd.Series | None,
+) -> tuple[np.ndarray, np.ndarray | None]:
+    if missing_policy == "impute_weight" and impute_means is not None:
+        X, w = impute_frame(chunk, impute_means)
+        return X.values, w.values
+    valid = chunk.notna().all(axis=1)
+    return chunk[valid].values, None

--- a/src/py3r/behaviour/features/cluster_pipeline.py
+++ b/src/py3r/behaviour/features/cluster_pipeline.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 from sklearn.cluster import KMeans, MiniBatchKMeans
 
+from py3r.behaviour.features.centroids_df import CentroidsDf
 from py3r.behaviour.features.features import Features, FeaturesResult
 from py3r.behaviour.util.missing_tolerance import fit_frame_imputer, impute_frame
 from py3r.behaviour.util.series_utils import (
@@ -65,11 +66,7 @@ class Assigner(Protocol):
     def assign_lowmem(
         self,
         fc,
-        embedding_dict: dict[str, list[int]],
-        centroids: pd.DataFrame,
-        *,
-        scaling_factors: dict | None,
-        impute_medians: pd.Series | None,
+        centroids_obj: CentroidsDf,
     ) -> dict: ...
 
     def combined_labels(
@@ -183,11 +180,7 @@ class DefaultAssigner:
     def assign_lowmem(
         self,
         fc,
-        embedding_dict: dict[str, list[int]],
-        centroids: pd.DataFrame,
-        *,
-        scaling_factors: dict | None,
-        impute_medians: pd.Series | None,
+        centroids_obj: CentroidsDf,
     ) -> dict:
         is_grouped = getattr(fc, "is_grouped", False)
         result_dict = {}
@@ -201,12 +194,8 @@ class DefaultAssigner:
             else ((None, fn, f) for fn, f in fc.features_dict.items())
         )
         for gkey, feat_name, feat in items:
-            fr = feat.assign_clusters_by_centroids(
-                embedding_dict,
-                centroids,
-                scaling_factors=scaling_factors,
-                impute_medians=impute_medians,
-            )
+            # impute_medians is read automatically from centroids_obj.scaling_recipe
+            fr = feat.assign_clusters_by_centroids(centroids_obj)
             if is_grouped:
                 result_dict.setdefault(gkey, {})[feat_name] = fr
             else:
@@ -317,9 +306,6 @@ class ClusteringPipeline:
                 if constant_factors is not None:
                     combined = combined * pd.Series(constant_factors)
 
-            scaling_recipe = _build_scaling_recipe(
-                embedding_dict, embed_cols, resolved_norm, constant_factors
-            )
         else:
             combined, norm = self.pre.scale(
                 build.combined,
@@ -330,12 +316,22 @@ class ClusteringPipeline:
             first_feat = next(_iter_features(fc))[2]
             embed_cols = list(first_feat.embedding_df(embedding_dict).columns)
             resolved_norm = {c: "none" for c in embed_cols}
-            scaling_recipe = _build_scaling_recipe(embedding_dict, embed_cols, resolved_norm, norm)
 
         X, w, impute_medians, valid_mask = self.missing.prepare(combined, cfg.missing_policy)
-        model, centroids = self.clusterer.fit(
+        model, centroids_df = self.clusterer.fit(
             X, sample_weight=w, n_clusters=cfg.n_clusters, random_state=cfg.random_state
         )
+
+        # Build recipe after impute_medians is known (it depends on missing_policy).
+        if using_new:
+            scaling_recipe = _build_scaling_recipe(
+                embedding_dict, embed_cols, resolved_norm, constant_factors, impute_medians
+            )
+        else:
+            scaling_recipe = _build_scaling_recipe(
+                embedding_dict, embed_cols, resolved_norm, norm, impute_medians
+            )
+        centroids = CentroidsDf(df=centroids_df, scaling_recipe=scaling_recipe)
 
         meta = {
             "embedding_dict": embedding_dict,
@@ -355,35 +351,8 @@ class ClusteringPipeline:
         }
 
         if cfg.lowmem:
-            if using_new:
-                is_grouped = getattr(fc, "is_grouped", False)
-                result_dict = {}
-                for gkey, feat_name, feat in _iter_features(fc):
-                    per_sf = _scaling_for_features(
-                        feat,
-                        embedding_dict,
-                        resolved_norm=resolved_norm,
-                        resolved_weights=resolved_weights,
-                        global_base_stds=global_base_stds,
-                    )
-                    fr = feat.assign_clusters_by_centroids(
-                        embedding_dict,
-                        centroids,
-                        scaling_factors=per_sf,
-                        impute_medians=impute_medians,
-                    )
-                    if is_grouped:
-                        result_dict.setdefault(gkey, {})[feat_name] = fr
-                    else:
-                        result_dict[feat_name] = fr
-            else:
-                result_dict = self.assigner.assign_lowmem(
-                    fc,
-                    embedding_dict,
-                    centroids,
-                    scaling_factors=norm,
-                    impute_medians=impute_medians,
-                )
+            # impute_medians is embedded in centroids.scaling_recipe
+            result_dict = self.assigner.assign_lowmem(fc, centroids)
             return result_dict, centroids, norm, meta
 
         # Non-lowmem: reconstruct per-feature FeaturesResult from combined_labels
@@ -633,6 +602,7 @@ def _build_scaling_recipe(
     columns: list[str],
     resolved_norm: dict[str, Literal["individual", "global", "none"]],
     constant_factors: dict[str, float] | None,
+    impute_medians: pd.Series | None = None,
 ) -> dict:
     """
     Build the minimal scaling recipe stored inside a ``CentroidsDf``.
@@ -647,6 +617,11 @@ def _build_scaling_recipe(
         Per-column normalisation mode, already resolved from user rules.
     constant_factors :
         The ``scaling_factors`` constant multipliers (weights + global norms).
+    impute_medians :
+        Per-column fill values used during training when
+        ``missing_policy="impute_weight"``.  Stored so future calls to
+        ``assign_clusters_by_centroids`` can reproduce the same imputation.
+        ``None`` when ``missing_policy="drop"``.
     """
     normalize_individual_base: dict[str, bool] = {}
     for base in embedding_dict:
@@ -660,6 +635,7 @@ def _build_scaling_recipe(
         "columns": columns,
         "normalize_individual_base": normalize_individual_base,
         "constant_factors": {} if constant_factors is None else dict(constant_factors),
+        "impute_medians": None if impute_medians is None else impute_medians.to_dict(),
     }
 
 
@@ -784,11 +760,11 @@ class StreamingClusteringPipeline:
                         continue
                     model.partial_fit(X, sample_weight=w)
 
-        centroids = pd.DataFrame(model.cluster_centers_, columns=columns)
-
+        centroids_df = pd.DataFrame(model.cluster_centers_, columns=columns)
         scaling_recipe = _build_scaling_recipe(
-            embedding_dict, list(embed_cols), resolved_norm, constant_factors
+            embedding_dict, list(embed_cols), resolved_norm, constant_factors, impute_means
         )
+        centroids = CentroidsDf(df=centroids_df, scaling_recipe=scaling_recipe)
 
         meta = {
             "function": "cluster_embedding_stream",
@@ -807,16 +783,7 @@ class StreamingClusteringPipeline:
             "scaling_recipe": scaling_recipe,
         }
 
-        result_dict = self._assign_all(
-            fc,
-            embedding_dict,
-            centroids,
-            resolved_norm=resolved_norm,
-            resolved_weights=resolved_weights,
-            global_base_stds=global_base_stds,
-            impute_means=impute_means,
-            meta=meta,
-        )
+        result_dict = self._assign_all(fc, centroids, meta=meta)
         return result_dict, centroids, constant_factors, meta
 
     # -- internal helpers ---------------------------------------------------
@@ -884,31 +851,15 @@ class StreamingClusteringPipeline:
     @staticmethod
     def _assign_all(
         fc,
-        embedding_dict: dict[str, list[int]],
-        centroids: pd.DataFrame,
+        centroids: CentroidsDf,
         *,
-        resolved_norm: dict[str, Literal["individual", "global", "none"]],
-        resolved_weights: dict[str, float] | None,
-        global_base_stds: dict[str, float],
-        impute_means: pd.Series | None,
         meta: dict,
     ) -> dict:
         is_grouped = getattr(fc, "is_grouped", False)
         result_dict: dict = {}
         for gkey, feat_name, feat in _iter_features(fc):
-            per_sf = _scaling_for_features(
-                feat,
-                embedding_dict,
-                resolved_norm=resolved_norm,
-                resolved_weights=resolved_weights,
-                global_base_stds=global_base_stds,
-            )
-            fr = feat.assign_clusters_by_centroids(
-                embedding_dict,
-                centroids,
-                scaling_factors=per_sf,
-                impute_medians=impute_means,
-            )
+            # impute_medians is read automatically from centroids.scaling_recipe
+            fr = feat.assign_clusters_by_centroids(centroids)
             if is_grouped:
                 result_dict.setdefault(gkey, {})[feat_name] = fr
             else:

--- a/src/py3r/behaviour/features/cluster_pipeline.py
+++ b/src/py3r/behaviour/features/cluster_pipeline.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, Protocol
+from typing import Literal
 
 import numpy as np
 import pandas as pd
@@ -31,154 +31,103 @@ class ClusteringConfig:
 
 
 # ---------------------------------------------------------------------------
-# Injection seams (for testing)
+# Fitting
 # ---------------------------------------------------------------------------
 
 
-class Assigner(Protocol):
-    def assign_all(self, fc, centroids: CentroidsDf) -> dict: ...
-
-
-class DefaultAssigner:
-    def assign_all(self, fc, centroids: CentroidsDf) -> dict:
-        is_grouped = getattr(fc, "is_grouped", False)
-        result_dict: dict = {}
-        for gkey, feat_name, feat in _iter_features(fc):
-            # impute_medians is read automatically from centroids.scaling_recipe
-            fr = feat.assign_clusters_by_centroids(centroids)
-            if is_grouped:
-                result_dict.setdefault(gkey, {})[feat_name] = fr
-            else:
-                result_dict[feat_name] = fr
-        return result_dict
-
-
-# ---------------------------------------------------------------------------
-# Pipeline
-# ---------------------------------------------------------------------------
-
-
-class ClusteringPipeline:
+def fit_cluster_embedding(
+    fc,
+    embedding_dict: dict[str, list[int]],
+    cfg: ClusteringConfig,
+) -> CentroidsDf:
     """
-    Memory-friendly clustering via MiniBatchKMeans.partial_fit.
+    Fit MiniBatchKMeans on *fc* and return a ``CentroidsDf``.
 
     Phases
     ------
     1. Resolve normalisation modes and validate feature weights.
-    2. Compute global stds (if any column uses "global" normalisation).
-    3. Compute imputation means (if missing_policy="impute_weight").
-    4. n_epochs passes of partial_fit, one Features at a time, chunk by chunk.
-    5. Per-Features assignment using the fitted centroids.
+    2. Compute global stds (if any column uses ``"global"`` normalisation).
+    3. Compute imputation means (if ``missing_policy="impute_weight"``).
+    4. *n_epochs* passes of ``partial_fit``, one Features at a time, chunk by chunk.
 
-    The ``CentroidsDf`` returned as the second element of the result tuple
-    carries a ``scaling_recipe`` with everything needed to reproduce the
-    transform on future datasets (embedding, per-column norm flags, constant
-    factors, and imputation means).
+    The returned ``CentroidsDf`` carries a ``scaling_recipe`` with everything
+    needed to reproduce the transform on future datasets (embedding dict,
+    per-column normalisation flags, constant factors, imputation means).
+    Assignment is left to the caller.
     """
+    # -- Phase 1: resolve scaling -------------------------------------------
+    first_feat = next(_iter_features(fc))[2]
+    embed_cols = list(first_feat.embedding_df(embedding_dict).columns)
 
-    def __init__(self, assigner: Assigner | None = None):
-        self.assigner = assigner or DefaultAssigner()
+    resolved_weights: dict[str, float] | None = None
+    if cfg.feature_weights is not None:
+        resolved_weights = _resolve_feature_weights(embed_cols, cfg.feature_weights)
+        _validate_weights_consistent(fc, embedding_dict, resolved_weights)
 
-    def run(
-        self,
+    default_mode: Literal["global", "none"] = "global" if cfg.normalize else "none"
+    resolved_norm = _resolve_column_modes(embed_cols, cfg.normalize_details, default=default_mode)
+
+    # -- Phase 2: global stds -----------------------------------------------
+    bases_needed = {
+        _base_feature_for_column(c, embedding_dict)
+        for c, m in resolved_norm.items()
+        if m == "global"
+    }
+    global_base_stds = _compute_global_base_stds(fc, embedding_dict, bases_needed=bases_needed)
+
+    constant_factors = _constant_scaling_factors(
+        embed_cols,
+        embedding_dict,
+        resolved_norm=resolved_norm,
+        resolved_weights=resolved_weights,
+        global_base_stds=global_base_stds,
+    )
+
+    # -- Phase 3: imputation means ------------------------------------------
+    impute_means = _compute_impute_means(
         fc,
-        embedding_dict: dict[str, list[int]],
-        cfg: ClusteringConfig,
-    ) -> tuple[dict, CentroidsDf, dict[str, float] | None, dict]:
-        # -- Phase 1: resolve scaling -------------------------------------------
-        first_feat = next(_iter_features(fc))[2]
-        embed_cols = list(first_feat.embedding_df(embedding_dict).columns)
+        embedding_dict,
+        cfg,
+        embed_cols=embed_cols,
+        resolved_norm=resolved_norm,
+        resolved_weights=resolved_weights,
+        global_base_stds=global_base_stds,
+    )
 
-        resolved_weights: dict[str, float] | None = None
-        if cfg.feature_weights is not None:
-            resolved_weights = _resolve_feature_weights(embed_cols, cfg.feature_weights)
-            _validate_weights_consistent(fc, embedding_dict, resolved_weights)
+    # -- Phase 4: train -----------------------------------------------------
+    model = MiniBatchKMeans(
+        n_clusters=cfg.n_clusters,
+        random_state=cfg.random_state,
+        batch_size=cfg.batch_size,
+    )
 
-        default_mode: Literal["global", "none"] = "global" if cfg.normalize else "none"
-        resolved_norm = _resolve_column_modes(
-            embed_cols, cfg.normalize_details, default=default_mode
-        )
+    columns = None
+    for _epoch in range(cfg.n_epochs):
+        for _gkey, _fname, feat in _iter_features(fc):
+            embed_df = feat.embedding_df(embedding_dict).astype(np.float32)
+            per_sf = _scaling_for_features(
+                feat,
+                embedding_dict,
+                resolved_norm=resolved_norm,
+                resolved_weights=resolved_weights,
+                global_base_stds=global_base_stds,
+            )
+            if per_sf is not None:
+                embed_df = embed_df * pd.Series(per_sf)
+            columns = embed_df.columns
+            for start in range(0, len(embed_df), cfg.chunk_size):
+                chunk = embed_df.iloc[start : start + cfg.chunk_size]
+                X, w = _prepare_chunk(chunk, cfg.missing_policy, impute_means)
+                if len(X) == 0:
+                    continue
+                model.partial_fit(X, sample_weight=w)
 
-        # -- Phase 2: global stds -----------------------------------------------
-        bases_needed = {
-            _base_feature_for_column(c, embedding_dict)
-            for c, m in resolved_norm.items()
-            if m == "global"
-        }
-        global_base_stds = _compute_global_base_stds(fc, embedding_dict, bases_needed=bases_needed)
-
-        constant_factors = _constant_scaling_factors(
-            embed_cols,
-            embedding_dict,
-            resolved_norm=resolved_norm,
-            resolved_weights=resolved_weights,
-            global_base_stds=global_base_stds,
-        )
-
-        # -- Phase 3: imputation means ------------------------------------------
-        impute_means = _compute_impute_means(
-            fc,
-            embedding_dict,
-            cfg,
-            embed_cols=embed_cols,
-            resolved_norm=resolved_norm,
-            resolved_weights=resolved_weights,
-            global_base_stds=global_base_stds,
-        )
-
-        # -- Phase 4: train -----------------------------------------------------
-        model = MiniBatchKMeans(
-            n_clusters=cfg.n_clusters,
-            random_state=cfg.random_state,
-            batch_size=cfg.batch_size,
-        )
-
-        columns = None
-        for _epoch in range(cfg.n_epochs):
-            for _gkey, _fname, feat in _iter_features(fc):
-                embed_df = feat.embedding_df(embedding_dict).astype(np.float32)
-                per_sf = _scaling_for_features(
-                    feat,
-                    embedding_dict,
-                    resolved_norm=resolved_norm,
-                    resolved_weights=resolved_weights,
-                    global_base_stds=global_base_stds,
-                )
-                if per_sf is not None:
-                    embed_df = embed_df * pd.Series(per_sf)
-                columns = embed_df.columns
-                for start in range(0, len(embed_df), cfg.chunk_size):
-                    chunk = embed_df.iloc[start : start + cfg.chunk_size]
-                    X, w = _prepare_chunk(chunk, cfg.missing_policy, impute_means)
-                    if len(X) == 0:
-                        continue
-                    model.partial_fit(X, sample_weight=w)
-
-        # -- Phase 5: build centroids and assign --------------------------------
-        centroids_df = pd.DataFrame(model.cluster_centers_, columns=columns)
-        scaling_recipe = _build_scaling_recipe(
-            embedding_dict, list(embed_cols), resolved_norm, constant_factors, impute_means
-        )
-        centroids = CentroidsDf(df=centroids_df, scaling_recipe=scaling_recipe)
-
-        meta = {
-            "embedding_dict": embedding_dict,
-            "n_clusters": cfg.n_clusters,
-            "random_state": cfg.random_state,
-            "normalize": cfg.normalize,
-            "normalize_details": cfg.normalize_details,
-            "feature_weights": cfg.feature_weights,
-            "resolved_feature_weights": resolved_weights,
-            "missing_policy": cfg.missing_policy,
-            "chunk_size": cfg.chunk_size,
-            "n_epochs": cfg.n_epochs,
-            "batch_size": cfg.batch_size,
-            "impute_means": (impute_means.to_dict() if impute_means is not None else None),
-            "scaling_recipe": scaling_recipe,
-        }
-
-        result_dict = self.assigner.assign_all(fc, centroids)
-        return result_dict, centroids, constant_factors, meta
+    # -- Phase 5: build and return centroids --------------------------------
+    centroids_df = pd.DataFrame(model.cluster_centers_, columns=columns)
+    scaling_recipe = _build_scaling_recipe(
+        embedding_dict, list(embed_cols), resolved_norm, constant_factors, impute_means
+    )
+    return CentroidsDf(df=centroids_df, scaling_recipe=scaling_recipe)
 
 
 # ---------------------------------------------------------------------------
@@ -373,7 +322,7 @@ def _constant_scaling_factors(
     Constant per-embedding-column multipliers: weights plus global norm factors.
 
     Individual-mode columns contribute only their weight (not their per-Features
-    std, which varies).  This is the ``scaling_factors`` third return value.
+    std, which varies); the per-recording std is captured in the recipe.
 
     Returns ``None`` when all factors are 1.0.
     """
@@ -397,7 +346,7 @@ def _build_scaling_recipe(
     columns: list[str],
     resolved_norm: dict[str, Literal["individual", "global", "none"]],
     constant_factors: dict[str, float] | None,
-    impute_medians: pd.Series | None = None,
+    impute_means: pd.Series | None = None,
 ) -> dict:
     """
     Build the minimal scaling recipe stored inside a ``CentroidsDf``.
@@ -412,8 +361,8 @@ def _build_scaling_recipe(
         Per-column normalisation mode, already resolved from user rules.
     constant_factors :
         Constant multipliers (weights + global norms).
-    impute_medians :
-        Per-column fill values used during training when
+    impute_means :
+        Per-column fill values (training-set column means) used when
         ``missing_policy="impute_weight"``.  ``None`` when
         ``missing_policy="drop"``.
     """
@@ -429,7 +378,7 @@ def _build_scaling_recipe(
         "columns": columns,
         "normalize_individual_base": normalize_individual_base,
         "constant_factors": {} if constant_factors is None else dict(constant_factors),
-        "impute_medians": None if impute_medians is None else impute_medians.to_dict(),
+        "impute_means": None if impute_means is None else impute_means.to_dict(),
     }
 
 

--- a/src/py3r/behaviour/features/features.py
+++ b/src/py3r/behaviour/features/features.py
@@ -2232,7 +2232,9 @@ class Features:
             only_in_self = sorted(self_cols - centroid_cols)
             only_in_centroids = sorted(centroid_cols - self_cols)
 
-            if only_in_self and allow_missing_features in ("self", "both"):
+            # only_in_self: self produced columns the centroids don't have
+            #   → centroids are "missing" those → tolerated by "centroids" / "both"
+            if only_in_self and allow_missing_features in ("centroids", "both"):
                 warnings.warn(
                     f"allow_missing_features={allow_missing_features!r}: {len(only_in_self)} "
                     f"embedding column(s) produced by self have no counterpart in the centroids "
@@ -2247,7 +2249,9 @@ class Features:
                     f"{only_in_self}"
                 )
 
-            if only_in_centroids and allow_missing_features in ("centroids", "both"):
+            # only_in_centroids: centroids have columns self couldn't produce
+            #   → self is "missing" those base features → tolerated by "self" / "both"
+            if only_in_centroids and allow_missing_features in ("self", "both"):
                 warnings.warn(
                     f"allow_missing_features={allow_missing_features!r}: {len(only_in_centroids)} "
                     f"centroid column(s) have no counterpart in the self embedding "

--- a/src/py3r/behaviour/features/features.py
+++ b/src/py3r/behaviour/features/features.py
@@ -2008,6 +2008,7 @@ class Features:
         centroids_df,
         embedding: dict[str, list[int]] | None = None,
         *,
+        allow_missing_features: Literal["self", "centroids", "both"] | None = None,
         scaling_factors: dict[str, float] | None = None,
         impute_means: pd.Series | None = None,
         # Removed legacy params; retained for explicit migration errors.
@@ -2033,6 +2034,30 @@ class Features:
             The embedding dict used during fitting.  Required when *centroids_df*
             is a plain ``pd.DataFrame``; inferred from the recipe when
             *centroids_df* is a :class:`CentroidsDf`.
+        allow_missing_features : {"self", "centroids", "both"} or None
+            Controls whether cluster assignment is permitted when the full
+            embedding space is not available, by projecting into a shared
+            subspace of the columns that *both* sides can provide.
+
+            * ``"self"`` – tolerate base features missing from *this* object
+              (e.g. a missing animal in a multi-animal recording).  *centroids_df*
+              is expected to cover the full training embedding; only the columns
+              ``self`` can actually produce are used.
+            * ``"centroids"`` – tolerate the centroids having fewer columns
+              than the full embedding ``self`` would generate (e.g. centroids
+              fitted on a reduced feature set).  *self* must still carry all
+              requested base features; only the centroid columns are used.
+            * ``"both"`` – tolerate gaps on either side; the strict
+              intersection of what ``self`` can produce and what the centroids
+              contain is used.
+
+            In all three cases a :class:`UserWarning` is issued that
+            identifies which columns were dropped and from which side, so
+            the caller can verify the subspace is sensible.  A
+            :exc:`ValueError` is raised when no columns remain after
+            intersection regardless of the chosen mode.
+
+            ``None`` (default) raises if the column sets do not match exactly.
         scaling_factors : dict[str, float] | None
             Per-embedding-column constant multipliers.  Applied only when
             *centroids_df* is a plain DataFrame (legacy path).
@@ -2124,13 +2149,31 @@ class Features:
         if embedding is None:
             raise ValueError("embedding is required when centroids_df is a plain DataFrame")
 
+        # When self is allowed to have missing base features, pre-filter the
+        # embedding dict so that embedding_df() does not raise.
+        if allow_missing_features in ("self", "both"):
+            missing_bases = [k for k in embedding if k not in self.data.columns]
+            if missing_bases:
+                warnings.warn(
+                    f"allow_missing_features={allow_missing_features!r}: the following base "
+                    f"feature(s) are absent from self and their embedding columns will be "
+                    f"excluded from the subspace assignment: {missing_bases}",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                embedding = {k: v for k, v in embedding.items() if k not in missing_bases}
+
         embed_df = self.embedding_df(embedding)
 
         if scaling_recipe is not None:
             # Recipe path (authoritative): apply individual norm then constant factors.
             cols_expected = scaling_recipe.get("columns")
             if cols_expected is not None and list(embed_df.columns) != list(cols_expected):
-                raise ValueError("Embedding columns do not match centroids scaling recipe columns")
+                if allow_missing_features is None:
+                    raise ValueError(
+                        "Embedding columns do not match centroids scaling recipe columns"
+                    )
+                # With allow_missing_features the column sets will be reconciled below.
             embed_df = embed_df.copy()
             for base, do_individual in (
                 scaling_recipe.get("normalize_individual_base") or {}
@@ -2138,6 +2181,9 @@ class Features:
                 if not do_individual:
                     continue
                 if base not in self.data.columns:
+                    if allow_missing_features in ("self", "both"):
+                        # Already warned above when filtering the embedding; just skip.
+                        continue
                     raise ValueError(f"Base feature '{base}' missing for individual normalization")
                 vals = self.data[base].to_numpy(dtype=np.float64)
                 finite = vals[np.isfinite(vals)]
@@ -2149,7 +2195,11 @@ class Features:
                 embed_df.loc[:, base_cols] = embed_df[base_cols] / std
             constant = scaling_recipe.get("constant_factors") or {}
             if constant:
-                embed_df = embed_df * pd.Series(constant)
+                # Only scale columns present in embed_df; extra recipe keys are ignored
+                # (they would otherwise inject NaN columns via DataFrame * Series alignment).
+                constant_aligned = {k: v for k, v in constant.items() if k in embed_df.columns}
+                if constant_aligned:
+                    embed_df = embed_df * pd.Series(constant_aligned)
             # Read impute_means from recipe unless the caller already provided one.
             # Backward-compat: old recipes used the key "impute_medians".
             recipe_impute = scaling_recipe.get("impute_means") or scaling_recipe.get(
@@ -2173,8 +2223,61 @@ class Features:
         else:
             applied_meta = {}
 
-        if not embed_df.columns.equals(underlying_df.columns):
-            raise ValueError("Columns in embedding and centroids do not match")
+        if allow_missing_features is not None:
+            # Reconcile columns: work in the intersection of what self produced
+            # and what the centroids contain, with side-specific diagnostics.
+            self_cols = set(embed_df.columns)
+            centroid_cols = set(underlying_df.columns)
+
+            only_in_self = sorted(self_cols - centroid_cols)
+            only_in_centroids = sorted(centroid_cols - self_cols)
+
+            if only_in_self and allow_missing_features in ("self", "both"):
+                warnings.warn(
+                    f"allow_missing_features={allow_missing_features!r}: {len(only_in_self)} "
+                    f"embedding column(s) produced by self have no counterpart in the centroids "
+                    f"and will be dropped: {only_in_self}",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            elif only_in_self:
+                raise ValueError(
+                    f"Columns present in the self embedding but absent from the centroids "
+                    f"(pass allow_missing_features='centroids' or 'both' to allow this): "
+                    f"{only_in_self}"
+                )
+
+            if only_in_centroids and allow_missing_features in ("centroids", "both"):
+                warnings.warn(
+                    f"allow_missing_features={allow_missing_features!r}: {len(only_in_centroids)} "
+                    f"centroid column(s) have no counterpart in the self embedding "
+                    f"and will be dropped: {only_in_centroids}",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            elif only_in_centroids:
+                raise ValueError(
+                    f"Columns present in the centroids but absent from the self embedding "
+                    f"(pass allow_missing_features='self' or 'both' to allow this): "
+                    f"{only_in_centroids}"
+                )
+
+            # Preserve embed_df column order for the shared subspace.
+            shared_cols = [c for c in embed_df.columns if c in centroid_cols]
+            if not shared_cols:
+                raise ValueError(
+                    "No columns remain in common between the self embedding and the centroids "
+                    "after filtering. self produced: "
+                    f"{sorted(self_cols)}, centroids have: {sorted(centroid_cols)}"
+                )
+
+            embed_df = embed_df[shared_cols]
+            underlying_df = underlying_df[shared_cols]
+            if impute_means is not None:
+                impute_means = impute_means[impute_means.index.isin(shared_cols)]
+        else:
+            if not embed_df.columns.equals(underlying_df.columns):
+                raise ValueError("Columns in embedding and centroids do not match")
 
         if impute_means is not None:
             embed_df, _ = impute_frame(embed_df, impute_means)
@@ -2193,6 +2296,7 @@ class Features:
         meta = {
             "function": "assign_clusters_by_centroids",
             "embedding": embedding,
+            "allow_missing_features": allow_missing_features,
             **applied_meta,
         }
         return FeaturesResult(labels, self, name, meta)

--- a/src/py3r/behaviour/features/features.py
+++ b/src/py3r/behaviour/features/features.py
@@ -1937,6 +1937,7 @@ class Features:
         random_state: int = 0,
         *,
         normalize: bool = False,
+        normalize_details: dict[str, Literal["individual", "global", "none"]] | None = None,
         feature_weights: dict[str, float] | None = None,
         lowmem: bool = False,
         decimation_factor: int = 10,
@@ -1954,7 +1955,7 @@ class Features:
 
         Returns
         -------
-        (FeaturesResult, centroids DataFrame, scaling_factors or None)
+        (FeaturesResult, CentroidsDf, scaling_factors or None)
 
         Examples
         --------
@@ -1968,7 +1969,7 @@ class Features:
         >>> f = Features(t)
         >>> f.store(pd.Series(range(len(t.data)), index=t.data.index), 'counter')
         >>> result, centroids, norm = f.cluster_embedding({'counter': [0]}, n_clusters=2)
-        >>> isinstance(centroids, pd.DataFrame)
+        >>> hasattr(centroids, 'columns')
         True
         >>> len(result) == len(f.data)
         True
@@ -1991,6 +1992,7 @@ class Features:
             n_clusters,
             random_state,
             normalize=normalize,
+            normalize_details=normalize_details,
             feature_weights=feature_weights,
             lowmem=lowmem,
             decimation_factor=decimation_factor,
@@ -2008,6 +2010,7 @@ class Features:
         random_state: int = 0,
         *,
         normalize: bool = False,
+        normalize_details: dict[str, Literal["individual", "global", "none"]] | None = None,
         feature_weights: dict[str, float] | None = None,
         missing_policy: Literal["drop", "impute_weight"] = "drop",
         chunk_size: int = 10_000,
@@ -2022,7 +2025,7 @@ class Features:
 
         Returns
         -------
-        (FeaturesResult, centroids DataFrame, scaling_factors or None)
+        (FeaturesResult, CentroidsDf, scaling_factors or None)
 
         Examples
         --------
@@ -2037,7 +2040,7 @@ class Features:
         >>> f.store(pd.Series(range(len(t.data)), index=t.data.index), 'counter')
         >>> result, centroids, norm = f.cluster_embedding_stream(
         ...     {'counter': [0]}, n_clusters=2)
-        >>> isinstance(centroids, pd.DataFrame)
+        >>> hasattr(centroids, 'columns')
         True
         >>> len(result) == len(f.data)
         True
@@ -2052,6 +2055,7 @@ class Features:
             n_clusters,
             random_state,
             normalize=normalize,
+            normalize_details=normalize_details,
             feature_weights=feature_weights,
             missing_policy=missing_policy,
             chunk_size=chunk_size,
@@ -2063,7 +2067,7 @@ class Features:
     def assign_clusters_by_centroids(
         self,
         embedding: dict[str, list[int]],
-        centroids_df: pd.DataFrame,
+        centroids_df,
         *,
         scaling_factors: dict[str, float] | None = None,
         impute_medians: pd.Series | None = None,
@@ -2078,14 +2082,21 @@ class Features:
         ----------
         embedding : dict[str, list[int]]
             Same embedding dict used during fitting.
-        centroids_df : pd.DataFrame
-            (n_clusters, n_features) DataFrame of cluster centres.
+        centroids_df : CentroidsDf or pd.DataFrame
+            Cluster centres.  Passing a
+            :class:`~py3r.behaviour.features.centroids_df.CentroidsDf` (the
+            object returned by ``cluster_embedding*``) is preferred: the method
+            will automatically apply the stored ``scaling_recipe``, including any
+            per-recording individual normalisation.
+
+            If a plain ``pd.DataFrame`` is passed, *scaling_factors* is used
+            instead (legacy path).
         scaling_factors : dict[str, float] | None
-            Per-embedding-column multipliers (the "dumb" scalars returned by
-            ``cluster_embedding_stream``).  Each raw embedding column is
-            multiplied by the corresponding value before distance computation.
+            Per-embedding-column constant multipliers.  Applied only when
+            *centroids_df* is a plain DataFrame (legacy path).
         impute_medians : pd.Series | None
             Per-column fill values for NaN imputation (from training).
+
         Returns
         -------
         FeaturesResult
@@ -2115,6 +2126,8 @@ class Features:
         """
         from sklearn.metrics.pairwise import pairwise_distances_argmin
 
+        from py3r.behaviour.features.centroids_df import CentroidsDf
+
         if rescale_factors is not None:
             raise NotImplementedError("rescale_factors was removed; pass scaling_factors instead.")
         if custom_scaling is not None:
@@ -2123,12 +2136,50 @@ class Features:
                 "and pass scaling_factors instead."
             )
 
+        # Unwrap CentroidsDf and extract scaling recipe.
+        scaling_recipe: dict | None = None
+        underlying_df: pd.DataFrame
+        if isinstance(centroids_df, CentroidsDf):
+            scaling_recipe = centroids_df.scaling_recipe
+            underlying_df = centroids_df.df
+        else:
+            underlying_df = centroids_df
+
         embed_df = self.embedding_df(embedding)
 
-        if scaling_factors is not None:
+        if scaling_recipe is not None:
+            # Recipe path (authoritative): apply individual norm then constant factors.
+            cols_expected = scaling_recipe.get("columns")
+            if cols_expected is not None and list(embed_df.columns) != list(cols_expected):
+                raise ValueError("Embedding columns do not match centroids scaling recipe columns")
+            embed_df = embed_df.copy()
+            for base, do_individual in (
+                scaling_recipe.get("normalize_individual_base") or {}
+            ).items():
+                if not do_individual:
+                    continue
+                if base not in self.data.columns:
+                    raise ValueError(f"Base feature '{base}' missing for individual normalization")
+                vals = self.data[base].to_numpy(dtype=np.float64)
+                finite = vals[np.isfinite(vals)]
+                std = float(np.std(finite)) if finite.size > 0 else 1.0
+                std = std if std > 0 else 1.0
+                base_cols = [c for c in embed_df.columns if c.startswith(base + "_t")]
+                if not base_cols:
+                    raise ValueError(f"No embedding columns found for base feature '{base}'")
+                embed_df.loc[:, base_cols] = embed_df[base_cols] / std
+            constant = scaling_recipe.get("constant_factors") or {}
+            if constant:
+                embed_df = embed_df * pd.Series(constant)
+            applied_meta: dict = {"scaling_recipe": scaling_recipe}
+        elif scaling_factors is not None:
+            # Legacy path: plain constant multipliers.
             embed_df = embed_df * pd.Series(scaling_factors)
+            applied_meta = {"scaling_factors": scaling_factors}
+        else:
+            applied_meta = {}
 
-        if not embed_df.columns.equals(centroids_df.columns):
+        if not embed_df.columns.equals(underlying_df.columns):
             raise ValueError("Columns in embedding and centroids do not match")
 
         if impute_medians is not None:
@@ -2138,17 +2189,17 @@ class Features:
         else:
             mask = embed_df.notna().all(axis=1)
             embed_values = embed_df[mask].values
-        centroids_values = centroids_df.values
+        centroids_values = underlying_df.values
 
         labels = pd.Series(pd.NA, index=embed_df.index, dtype="Int64")
         if len(embed_values) > 0:
             labels[mask] = pairwise_distances_argmin(embed_values, centroids_values)
 
-        name = f"kmeans_{len(centroids_df.index)}"
+        name = f"kmeans_{len(underlying_df.index)}"
         meta = {
             "function": "assign_clusters_by_centroids",
             "embedding": embedding,
-            "scaling_factors": scaling_factors,
+            **applied_meta,
         }
         return FeaturesResult(labels, self, name, meta)
 

--- a/src/py3r/behaviour/features/features.py
+++ b/src/py3r/behaviour/features/features.py
@@ -1964,7 +1964,7 @@ class Features:
 
         Returns
         -------
-        (FeaturesResult, CentroidsDf, scaling_factors or None)
+        (FeaturesResult, CentroidsDf)
 
         Examples
         --------
@@ -1977,7 +1977,7 @@ class Features:
         ...     t = Tracking.from_dlc(str(p), handle='ex', fps=30)
         >>> f = Features(t)
         >>> f.store(pd.Series(range(len(t.data)), index=t.data.index), 'counter')
-        >>> result, centroids, norm = f.cluster_embedding_stream(
+        >>> result, centroids = f.cluster_embedding_stream(
         ...     {'counter': [0]}, n_clusters=2)
         >>> hasattr(centroids, 'columns')
         True
@@ -1989,7 +1989,7 @@ class Features:
         from py3r.behaviour.features.features_collection import FeaturesCollection
 
         fc = FeaturesCollection.from_list([self])
-        batch, centroids, scaling = fc.cluster_embedding_stream(
+        batch, centroids = fc.cluster_embedding_stream(
             embedding_dict,
             n_clusters,
             random_state,
@@ -2001,7 +2001,7 @@ class Features:
             n_epochs=n_epochs,
             batch_size=batch_size,
         )
-        return batch[self.handle], centroids, scaling
+        return batch[self.handle], centroids
 
     def assign_clusters_by_centroids(
         self,
@@ -2009,7 +2009,7 @@ class Features:
         embedding: dict[str, list[int]] | None = None,
         *,
         scaling_factors: dict[str, float] | None = None,
-        impute_medians: pd.Series | None = None,
+        impute_means: pd.Series | None = None,
         # Removed legacy params; retained for explicit migration errors.
         rescale_factors: dict | None = None,
         custom_scaling: dict[str, dict] | None = None,
@@ -2036,8 +2036,11 @@ class Features:
         scaling_factors : dict[str, float] | None
             Per-embedding-column constant multipliers.  Applied only when
             *centroids_df* is a plain DataFrame (legacy path).
-        impute_medians : pd.Series | None
-            Per-column fill values for NaN imputation (from training).
+        impute_means : pd.Series | None
+            Per-column fill values (training-set column means) for NaN
+            imputation.  When *centroids_df* is a :class:`CentroidsDf` this is
+            read automatically from the ``scaling_recipe``; pass explicitly only
+            to override.
 
         Returns
         -------
@@ -2147,18 +2150,21 @@ class Features:
             constant = scaling_recipe.get("constant_factors") or {}
             if constant:
                 embed_df = embed_df * pd.Series(constant)
-            # Read impute_medians from recipe unless the caller already provided one.
-            recipe_impute = scaling_recipe.get("impute_medians")
-            if impute_medians is not None and recipe_impute is not None:
+            # Read impute_means from recipe unless the caller already provided one.
+            # Backward-compat: old recipes used the key "impute_medians".
+            recipe_impute = scaling_recipe.get("impute_means") or scaling_recipe.get(
+                "impute_medians"
+            )
+            if impute_means is not None and recipe_impute is not None:
                 warnings.warn(
-                    "impute_medians is already stored in the CentroidsDf scaling recipe "
+                    "impute_means is already stored in the CentroidsDf scaling recipe "
                     "and would be used automatically; passing it explicitly overrides the "
                     "recipe values.",
                     UserWarning,
                     stacklevel=2,
                 )
-            elif impute_medians is None and recipe_impute is not None:
-                impute_medians = pd.Series(recipe_impute)
+            elif impute_means is None and recipe_impute is not None:
+                impute_means = pd.Series(recipe_impute)
             applied_meta: dict = {"scaling_recipe": scaling_recipe}
         elif scaling_factors is not None:
             # Legacy path: plain constant multipliers.
@@ -2170,8 +2176,8 @@ class Features:
         if not embed_df.columns.equals(underlying_df.columns):
             raise ValueError("Columns in embedding and centroids do not match")
 
-        if impute_medians is not None:
-            embed_df, _ = impute_frame(embed_df, impute_medians)
+        if impute_means is not None:
+            embed_df, _ = impute_frame(embed_df, impute_means)
             mask = pd.Series(True, index=embed_df.index)
             embed_values = embed_df.values
         else:

--- a/src/py3r/behaviour/features/features.py
+++ b/src/py3r/behaviour/features/features.py
@@ -1930,78 +1930,17 @@ class Features:
         embed_df = pd.DataFrame(data, index=self.data.index)
         return embed_df
 
-    def cluster_embedding(
-        self,
-        embedding_dict: dict[str, list[int]],
-        n_clusters: int,
-        random_state: int = 0,
-        *,
-        normalize: bool = False,
-        normalize_details: dict[str, Literal["individual", "global", "none"]] | None = None,
-        feature_weights: dict[str, float] | None = None,
-        lowmem: bool = False,
-        decimation_factor: int = 10,
-        missing_policy: Literal["drop", "impute_weight"] = "drop",
-        # Removed legacy params; retained for explicit migration errors.
-        auto_normalize: bool = False,
-        rescale_factors: dict | None = None,
-        custom_scaling: dict[str, dict] | None = None,
-    ):
-        """
-        Perform k-means clustering on a single Features object.
-
-        Delegates to ``FeaturesCollection.cluster_embedding``.
-        See that method for full parameter documentation.
-
-        Returns
-        -------
-        (FeaturesResult, CentroidsDf, scaling_factors or None)
-
-        Examples
-        --------
-        ```pycon
-        >>> import pandas as pd
-        >>> from py3r.behaviour.util.docdata import data_path
-        >>> from py3r.behaviour.tracking.tracking import Tracking
-        >>> from py3r.behaviour.features.features import Features
-        >>> with data_path('py3r.behaviour.tracking._data', 'dlc_single.csv') as p:
-        ...     t = Tracking.from_dlc(str(p), handle='ex', fps=30)
-        >>> f = Features(t)
-        >>> f.store(pd.Series(range(len(t.data)), index=t.data.index), 'counter')
-        >>> result, centroids, norm = f.cluster_embedding({'counter': [0]}, n_clusters=2)
-        >>> hasattr(centroids, 'columns')
-        True
-        >>> len(result) == len(f.data)
-        True
-
-        ```
-        """
-        if auto_normalize:
-            raise NotImplementedError("auto_normalize was removed; use normalize=True instead.")
-        if rescale_factors is not None:
-            raise NotImplementedError(
-                "rescale_factors was removed; use normalize and/or feature_weights instead."
-            )
-        if custom_scaling is not None:
-            raise NotImplementedError("custom_scaling was removed; use feature_weights instead.")
-        from py3r.behaviour.features.features_collection import FeaturesCollection
-
-        fc = FeaturesCollection.from_list([self])
-        batch, centroids, norm = fc.cluster_embedding(
-            embedding_dict,
-            n_clusters,
-            random_state,
-            normalize=normalize,
-            normalize_details=normalize_details,
-            feature_weights=feature_weights,
-            lowmem=lowmem,
-            decimation_factor=decimation_factor,
-            missing_policy=missing_policy,
-            auto_normalize=auto_normalize,
-            rescale_factors=rescale_factors,
-            custom_scaling=custom_scaling,
+    def cluster_embedding(self, *args, **kwargs):
+        """Removed in py3r.behaviour 3.3.0. Use :meth:`cluster_embedding_stream` instead."""
+        raise NotImplementedError(
+            "cluster_embedding() was removed in py3r.behaviour 3.3.0.  "
+            "Use cluster_embedding_stream() instead.\n"
+            "Note: cluster_embedding_stream uses MiniBatchKMeans (stochastic updates) "
+            "rather than the full-batch KMeans of the old method — results will not be "
+            "bit-for-bit identical.  For well-separated data the partition will match; "
+            "increase n_epochs and batch_size to improve convergence for harder cases.  "
+            "To reproduce results from py3r ≤ 3.2.1 exactly, pin to that version."
         )
-        return batch[self.handle], centroids, norm
 
     def cluster_embedding_stream(
         self,

--- a/src/py3r/behaviour/features/features.py
+++ b/src/py3r/behaviour/features/features.py
@@ -2066,8 +2066,8 @@ class Features:
 
     def assign_clusters_by_centroids(
         self,
-        embedding: dict[str, list[int]],
         centroids_df,
+        embedding: dict[str, list[int]] | None = None,
         *,
         scaling_factors: dict[str, float] | None = None,
         impute_medians: pd.Series | None = None,
@@ -2080,17 +2080,20 @@ class Features:
 
         Parameters
         ----------
-        embedding : dict[str, list[int]]
-            Same embedding dict used during fitting.
         centroids_df : CentroidsDf or pd.DataFrame
             Cluster centres.  Passing a
             :class:`~py3r.behaviour.features.centroids_df.CentroidsDf` (the
             object returned by ``cluster_embedding*``) is preferred: the method
             will automatically apply the stored ``scaling_recipe``, including any
-            per-recording individual normalisation.
+            per-recording individual normalisation, and infer the *embedding*
+            from the recipe so it need not be passed separately.
 
-            If a plain ``pd.DataFrame`` is passed, *scaling_factors* is used
-            instead (legacy path).
+            If a plain ``pd.DataFrame`` is passed, *embedding* and optionally
+            *scaling_factors* must be provided (legacy path).
+        embedding : dict[str, list[int]] | None
+            The embedding dict used during fitting.  Required when *centroids_df*
+            is a plain ``pd.DataFrame``; inferred from the recipe when
+            *centroids_df* is a :class:`CentroidsDf`.
         scaling_factors : dict[str, float] | None
             Per-embedding-column constant multipliers.  Applied only when
             *centroids_df* is a plain DataFrame (legacy path).
@@ -2118,12 +2121,14 @@ class Features:
         >>> df = f.embedding_df(emb)
         >>> # make 2 simple centroids matching columns
         >>> cents = pd.DataFrame([[0, 0], [1, 1]], columns=df.columns)
-        >>> labels = f.assign_clusters_by_centroids(emb, cents)
+        >>> labels = f.assign_clusters_by_centroids(cents, emb)
         >>> isinstance(labels, pd.Series) and len(labels) == len(t.data)
         True
 
         ```
         """
+        import warnings
+
         from sklearn.metrics.pairwise import pairwise_distances_argmin
 
         from py3r.behaviour.features.centroids_df import CentroidsDf
@@ -2136,14 +2141,46 @@ class Features:
                 "and pass scaling_factors instead."
             )
 
+        # Detect legacy argument order: assign_clusters_by_centroids(embedding, centroids_df).
+        # A dict can only be the embedding; a DataFrame/CentroidsDf can only be centroids.
+        if isinstance(centroids_df, dict):
+            warnings.warn(
+                "The argument order for assign_clusters_by_centroids has changed: "
+                "pass centroids first, then (optionally) embedding. "
+                "Old: feat.assign_clusters_by_centroids(embedding, centroids_df) — "
+                "New: feat.assign_clusters_by_centroids(centroids_df, embedding)",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            centroids_df, embedding = embedding, centroids_df
+
         # Unwrap CentroidsDf and extract scaling recipe.
         scaling_recipe: dict | None = None
         underlying_df: pd.DataFrame
         if isinstance(centroids_df, CentroidsDf):
             scaling_recipe = centroids_df.scaling_recipe
             underlying_df = centroids_df.df
+            recipe_embedding = scaling_recipe.get("embedding_dict")
+            if embedding is not None and recipe_embedding is not None:
+                if embedding != recipe_embedding:
+                    raise ValueError(
+                        "The provided embedding dict does not match the one stored in the "
+                        "CentroidsDf scaling recipe. Pass centroids only (without embedding) "
+                        "to use the recipe's embedding, or ensure the dicts match."
+                    )
+                warnings.warn(
+                    "The embedding dict is already stored in the CentroidsDf scaling recipe "
+                    "and will be used automatically; passing it explicitly is redundant.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            if embedding is None:
+                embedding = recipe_embedding
         else:
             underlying_df = centroids_df
+
+        if embedding is None:
+            raise ValueError("embedding is required when centroids_df is a plain DataFrame")
 
         embed_df = self.embedding_df(embedding)
 
@@ -2171,6 +2208,18 @@ class Features:
             constant = scaling_recipe.get("constant_factors") or {}
             if constant:
                 embed_df = embed_df * pd.Series(constant)
+            # Read impute_medians from recipe unless the caller already provided one.
+            recipe_impute = scaling_recipe.get("impute_medians")
+            if impute_medians is not None and recipe_impute is not None:
+                warnings.warn(
+                    "impute_medians is already stored in the CentroidsDf scaling recipe "
+                    "and would be used automatically; passing it explicitly overrides the "
+                    "recipe values.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            elif impute_medians is None and recipe_impute is not None:
+                impute_medians = pd.Series(recipe_impute)
             applied_meta: dict = {"scaling_recipe": scaling_recipe}
         elif scaling_factors is not None:
             # Legacy path: plain constant multipliers.

--- a/src/py3r/behaviour/features/features_collection.py
+++ b/src/py3r/behaviour/features/features_collection.py
@@ -5,12 +5,7 @@ from typing import TYPE_CHECKING, Literal
 import numpy as np
 import pandas as pd
 
-from py3r.behaviour.features.cluster_pipeline import (
-    ClusteringConfig,
-    ClusteringPipeline,
-    StreamingClusteringPipeline,
-    StreamingConfig,
-)
+from py3r.behaviour.features.cluster_pipeline import ClusteringConfig, ClusteringPipeline
 from py3r.behaviour.features.features import Features
 from py3r.behaviour.tracking.tracking_collection import TrackingCollection
 from py3r.behaviour.util.base_collection import BaseCollection
@@ -338,118 +333,17 @@ class FeaturesCollection(BaseCollection):
 
         return SummaryCollection.from_features_collection(self)
 
-    def cluster_embedding(
-        self,
-        embedding_dict: dict[str, list[int]],
-        n_clusters: int,
-        random_state: int = 0,
-        *,
-        normalize: bool = False,
-        normalize_details: dict[str, Literal["individual", "global", "none"]] | None = None,
-        feature_weights: dict[str, float] | None = None,
-        lowmem: bool = False,
-        decimation_factor: int = 10,
-        missing_policy: Literal["drop", "impute_weight"] = "drop",
-        # removed legacy params; retained for a clear migration error
-        auto_normalize: bool = False,
-        rescale_factors: dict | None = None,
-        custom_scaling: dict[str, dict] | None = None,
-    ):
-        """
-        Perform k-means clustering using the specified embedding.
-
-        Returns ``(BatchResult, centroids, scaling_factors)`` where *centroids*
-        is a :class:`~py3r.behaviour.features.centroids_df.CentroidsDf` (a
-        DataFrame-like wrapper that also carries a ``scaling_recipe`` for
-        reproducing the transform on future datasets) and *scaling_factors* is a
-        dict of one float per embedding column — the constant part of the
-        normalisation and feature weights (for columns using ``"individual"``
-        normalisation, the per-recording std is *not* included here; it is
-        captured in the recipe).
-
-        Parameters
-        ----------
-        normalize : bool
-            Divide each base feature by its global std before embedding.
-            Equivalent to ``normalize_details={"<all>": "global"}``.
-        normalize_details : dict[str, {"individual","global","none"}] | None
-            Optional substring→mode rules.  Each key is matched by substring
-            against embedding column names (e.g. ``"speed"`` matches
-            ``"speed_t0"``, ``"speed_t+1"``).
-
-            - ``"global"`` — divide by std computed across the whole collection.
-            - ``"individual"`` — divide by std computed within each Features.
-            - ``"none"`` — no normalisation for matching columns.
-
-            Rules must not overlap and each rule must match at least one column.
-            Unmatched columns default to ``"global"`` if *normalize* is True,
-            otherwise ``"none"``.
-        feature_weights : dict[str, float] | None
-            Substring → weight mapping, e.g. ``{"speed": 4.0, "accel": 2.0}``.
-            Each key is matched against embedding column names by substring;
-            matched columns are multiplied by the value.  Resolved internally
-            via :func:`~py3r.behaviour.util.series_utils.build_column_weights`.
-            Raises if a rule matches no column (likely typo).
-
-        Examples
-        --------
-        ```pycon
-        >>> import tempfile, shutil
-        >>> from pathlib import Path
-        >>> import pandas as pd
-        >>> from py3r.behaviour.util.docdata import data_path
-        >>> from py3r.behaviour.tracking.tracking_collection import TrackingCollection
-        >>> with tempfile.TemporaryDirectory() as d:
-        ...     d = Path(d)
-        ...     with data_path('py3r.behaviour.tracking._data', 'dlc_single.csv') as p:
-        ...         _ = shutil.copy(p, d / 'A.csv'); _ = shutil.copy(p, d / 'B.csv')
-        ...     tc = TrackingCollection.from_dlc({'A': str(d/'A.csv'), 'B': str(d/'B.csv')}, fps=30)
-        >>> fc = FeaturesCollection.from_tracking_collection(tc)
-        >>> # Create a trivial feature 'counter' in each Features to embed
-        >>> for f in fc.values():
-        ...     s = pd.Series(range(len(f.tracking.data)), index=f.tracking.data.index)
-        ...     f.store(s, 'counter')
-        >>> batch, centroids, norm = fc.cluster_embedding(
-        ...     {'counter':[0]}, n_clusters=2, lowmem=True)
-        >>> hasattr(centroids, 'columns')
-        True
-        >>> batch, centroids, norm = fc.cluster_embedding(
-        ...     {'counter':[0]}, n_clusters=2, lowmem=True,
-        ...     missing_policy='impute_weight')
-        >>> hasattr(centroids, 'columns')
-        True
-        >>> batch, centroids, norm = fc.cluster_embedding(
-        ...     {'counter':[0]}, n_clusters=2, lowmem=True,
-        ...     missing_policy='drop')
-        >>> hasattr(centroids, 'columns')
-        True
-
-        ```
-        """
-        if auto_normalize:
-            raise NotImplementedError("auto_normalize was removed; use normalize=True instead.")
-        if rescale_factors is not None:
-            raise NotImplementedError(
-                "rescale_factors was removed; use normalize and/or feature_weights instead."
-            )
-        if custom_scaling is not None:
-            raise NotImplementedError("custom_scaling was removed; use feature_weights instead.")
-        pipeline = ClusteringPipeline()
-        cfg = ClusteringConfig(
-            n_clusters=n_clusters,
-            random_state=random_state,
-            normalize=normalize,
-            normalize_details=normalize_details,
-            feature_weights=feature_weights,
-            auto_normalize=auto_normalize,
-            rescale_factors=rescale_factors,
-            lowmem=lowmem,
-            decimation_factor=decimation_factor,
-            custom_scaling=custom_scaling,
-            missing_policy=missing_policy,
+    def cluster_embedding(self, *args, **kwargs):
+        """Removed in py3r.behaviour 3.3.0. Use :meth:`cluster_embedding_stream` instead."""
+        raise NotImplementedError(
+            "cluster_embedding() was removed in py3r.behaviour 3.3.0.  "
+            "Use cluster_embedding_stream() instead.\n"
+            "Note: cluster_embedding_stream uses MiniBatchKMeans (stochastic updates) "
+            "rather than the full-batch KMeans of the old method — results will not be "
+            "bit-for-bit identical.  For well-separated data the partition will match; "
+            "increase n_epochs and batch_size to improve convergence for harder cases.  "
+            "To reproduce results from py3r.behaviour ≤ 3.2.1 exactly, pin to that version."
         )
-        result_dict, centroids, scaling_factors, _meta = pipeline.run(self, embedding_dict, cfg)
-        return BatchResult(result_dict, self), centroids, scaling_factors
 
     def cluster_embedding_stream(
         self,
@@ -466,18 +360,30 @@ class FeaturesCollection(BaseCollection):
         batch_size: int = 1024,
     ):
         """
-        Memory-friendly clustering via streaming MiniBatchKMeans.
+        K-means clustering via streaming ``MiniBatchKMeans``.
 
-        Unlike ``cluster_embedding``, this never builds a combined DataFrame.
-        Embeddings are extracted one Features at a time, sliced into
-        fixed-size chunks, and fed to ``MiniBatchKMeans.partial_fit``.
-        Multiple epochs improve convergence; uniform chunk sizes prevent
-        large recordings from dominating centroid updates.
+        Embeddings are extracted one ``Features`` at a time, sliced into
+        fixed-size chunks, and fed to ``MiniBatchKMeans.partial_fit`` over
+        multiple epochs.  The dataset is never concatenated into a single
+        combined DataFrame, so memory usage scales with the largest single
+        recording rather than the whole collection.
 
         Returns ``(BatchResult, centroids, scaling_factors)`` where *centroids*
-        is a :class:`~py3r.behaviour.features.centroids_df.CentroidsDf` and
-        *scaling_factors* is the constant part of the transform (see
-        :meth:`cluster_embedding` for full parameter documentation).
+        is a :class:`~py3r.behaviour.features.centroids_df.CentroidsDf`
+        carrying a ``scaling_recipe`` (embedding, normalisation flags, constant
+        factors, imputation means) needed to reproduce the transform on future
+        datasets.  *scaling_factors* is the constant part of the transform
+        (weights + global normalisation; per-recording stds for
+        ``"individual"`` columns are captured in the recipe, not here).
+
+        **Algorithm note** — this method uses ``MiniBatchKMeans`` (stochastic
+        online updates), which replaced the full-batch ``KMeans`` (Lloyd's
+        algorithm) removed in py3r 3.3.0.  Results are not bit-for-bit
+        identical to the old ``cluster_embedding``: on well-separated data the
+        partition will be the same; on harder problems, increasing ``n_epochs``
+        (5–10+) and ``batch_size`` (e.g. 2048–8192) improves convergence
+        toward the same local optimum.  To reproduce results from py3r ≤ 3.2.1
+        exactly, pin to that version.
 
         Parameters
         ----------
@@ -489,18 +395,39 @@ class FeaturesCollection(BaseCollection):
             Seed for reproducibility.
         normalize : bool
             Divide each base feature by its global std before embedding.
+            Equivalent to ``normalize_details={"<all>": "global"}``.
         normalize_details : dict[str, {"individual","global","none"}] | None
-            Per-column normalisation modes; see :meth:`cluster_embedding`.
+            Per-column normalisation modes, keyed by substring matched against
+            embedding column names.
+
+            - ``"global"`` — divide by std pooled across the whole collection.
+            - ``"individual"`` — divide by std computed within each Features.
+            - ``"none"`` — no normalisation for matching columns.
+
+            Rules must not overlap; each rule must match at least one column.
+            Unmatched columns default to ``"global"`` if *normalize* is True,
+            otherwise ``"none"``.
         feature_weights : dict[str, float] | None
-            Substring → weight mapping, e.g. ``{"speed": 4.0}``.
+            Substring → weight mapping, e.g. ``{"speed": 4.0, "accel": 2.0}``.
+            Matched columns are multiplied by the value after normalisation.
+            Raises if a rule matches no column (likely a typo).
         missing_policy : {"drop", "impute_weight"}
-            How to handle NaN rows.
+            How to handle NaN rows during training.  ``"drop"`` excludes them;
+            ``"impute_weight"`` fills with training-set column means and
+            up-weights complete rows proportionally.  The chosen means are
+            stored in the ``scaling_recipe`` so that the same policy is applied
+            automatically when assigning clusters to future recordings.
         chunk_size : int
-            Max rows per partial_fit call.
+            Maximum number of rows passed to a single ``partial_fit`` call.
+            Larger values reduce noise in centroid updates at the cost of
+            higher per-iteration memory use.
         n_epochs : int
-            Number of full passes over the data.
+            Number of full passes over the data.  More epochs → better
+            convergence.  3–5 is usually sufficient; increase for small or
+            noisy datasets, or to approximate full-batch KMeans more closely.
         batch_size : int
-            MiniBatchKMeans internal mini-batch size.
+            ``MiniBatchKMeans`` internal mini-batch size (passed directly to
+            sklearn).  Larger values reduce variance in updates.
 
         Examples
         --------
@@ -526,8 +453,8 @@ class FeaturesCollection(BaseCollection):
 
         ```
         """
-        pipeline = StreamingClusteringPipeline()
-        cfg = StreamingConfig(
+        pipeline = ClusteringPipeline()
+        cfg = ClusteringConfig(
             n_clusters=n_clusters,
             random_state=random_state,
             normalize=normalize,

--- a/src/py3r/behaviour/features/features_collection.py
+++ b/src/py3r/behaviour/features/features_collection.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Literal
 import numpy as np
 import pandas as pd
 
+from py3r.behaviour.features.centroids_df import CentroidsDf
 from py3r.behaviour.features.cluster_pipeline import (
     ClusteringConfig,
     ClusteringPipeline,
@@ -345,6 +346,7 @@ class FeaturesCollection(BaseCollection):
         random_state: int = 0,
         *,
         normalize: bool = False,
+        normalize_details: dict[str, Literal["individual", "global", "none"]] | None = None,
         feature_weights: dict[str, float] | None = None,
         lowmem: bool = False,
         decimation_factor: int = 10,
@@ -357,20 +359,39 @@ class FeaturesCollection(BaseCollection):
         """
         Perform k-means clustering using the specified embedding.
 
-        Returns ``(BatchResult, centroids, scaling_factors)`` where
-        *scaling_factors* is a dict of one float per embedding column —
-        the combined effect of normalisation and feature weights.
+        Returns ``(BatchResult, centroids, scaling_factors)`` where *centroids*
+        is a :class:`~py3r.behaviour.features.centroids_df.CentroidsDf` (a
+        DataFrame-like wrapper that also carries a ``scaling_recipe`` for
+        reproducing the transform on future datasets) and *scaling_factors* is a
+        dict of one float per embedding column — the constant part of the
+        normalisation and feature weights (for columns using ``"individual"``
+        normalisation, the per-recording std is *not* included here; it is
+        captured in the recipe).
 
         Parameters
         ----------
         normalize : bool
             Divide each base feature by its global std before embedding.
+            Equivalent to ``normalize_details={"<all>": "global"}``.
+        normalize_details : dict[str, {"individual","global","none"}] | None
+            Optional substring→mode rules.  Each key is matched by substring
+            against embedding column names (e.g. ``"speed"`` matches
+            ``"speed_t0"``, ``"speed_t+1"``).
+
+            - ``"global"`` — divide by std computed across the whole collection.
+            - ``"individual"`` — divide by std computed within each Features.
+            - ``"none"`` — no normalisation for matching columns.
+
+            Rules must not overlap and each rule must match at least one column.
+            Unmatched columns default to ``"global"`` if *normalize* is True,
+            otherwise ``"none"``.
         feature_weights : dict[str, float] | None
             Substring → weight mapping, e.g. ``{"speed": 4.0, "accel": 2.0}``.
             Each key is matched against embedding column names by substring;
             matched columns are multiplied by the value.  Resolved internally
             via :func:`~py3r.behaviour.util.series_utils.build_column_weights`.
             Raises if a rule matches no column (likely typo).
+
         Examples
         --------
         ```pycon
@@ -391,17 +412,17 @@ class FeaturesCollection(BaseCollection):
         ...     f.store(s, 'counter')
         >>> batch, centroids, norm = fc.cluster_embedding(
         ...     {'counter':[0]}, n_clusters=2, lowmem=True)
-        >>> isinstance(centroids, pd.DataFrame)
+        >>> hasattr(centroids, 'columns')
         True
         >>> batch, centroids, norm = fc.cluster_embedding(
         ...     {'counter':[0]}, n_clusters=2, lowmem=True,
         ...     missing_policy='impute_weight')
-        >>> isinstance(centroids, pd.DataFrame)
+        >>> hasattr(centroids, 'columns')
         True
         >>> batch, centroids, norm = fc.cluster_embedding(
         ...     {'counter':[0]}, n_clusters=2, lowmem=True,
         ...     missing_policy='drop')
-        >>> isinstance(centroids, pd.DataFrame)
+        >>> hasattr(centroids, 'columns')
         True
 
         ```
@@ -419,6 +440,7 @@ class FeaturesCollection(BaseCollection):
             n_clusters=n_clusters,
             random_state=random_state,
             normalize=normalize,
+            normalize_details=normalize_details,
             feature_weights=feature_weights,
             auto_normalize=auto_normalize,
             rescale_factors=rescale_factors,
@@ -427,7 +449,8 @@ class FeaturesCollection(BaseCollection):
             custom_scaling=custom_scaling,
             missing_policy=missing_policy,
         )
-        result_dict, centroids, scaling_factors, _meta = pipeline.run(self, embedding_dict, cfg)
+        result_dict, centroids_df, scaling_factors, meta = pipeline.run(self, embedding_dict, cfg)
+        centroids = CentroidsDf(df=centroids_df, scaling_recipe=meta["scaling_recipe"])
         return BatchResult(result_dict, self), centroids, scaling_factors
 
     def cluster_embedding_stream(
@@ -437,6 +460,7 @@ class FeaturesCollection(BaseCollection):
         random_state: int = 0,
         *,
         normalize: bool = False,
+        normalize_details: dict[str, Literal["individual", "global", "none"]] | None = None,
         feature_weights: dict[str, float] | None = None,
         missing_policy: Literal["drop", "impute_weight"] = "drop",
         chunk_size: int = 10_000,
@@ -452,14 +476,10 @@ class FeaturesCollection(BaseCollection):
         Multiple epochs improve convergence; uniform chunk sizes prevent
         large recordings from dominating centroid updates.
 
-        Normalisation is computed on base feature columns (before embedding)
-        so that all time-shifts of the same feature share the same std.
-        The returned ``scaling_factors`` is a dict of one float per
-        *embedding column* — the combined effect of normalisation and
-        feature weights.  Multiply raw embedding values by these to reproduce
-        the transform.
-
-        Returns ``(BatchResult, centroids, scaling_factors)``.
+        Returns ``(BatchResult, centroids, scaling_factors)`` where *centroids*
+        is a :class:`~py3r.behaviour.features.centroids_df.CentroidsDf` and
+        *scaling_factors* is the constant part of the transform (see
+        :meth:`cluster_embedding` for full parameter documentation).
 
         Parameters
         ----------
@@ -471,10 +491,10 @@ class FeaturesCollection(BaseCollection):
             Seed for reproducibility.
         normalize : bool
             Divide each base feature by its global std before embedding.
+        normalize_details : dict[str, {"individual","global","none"}] | None
+            Per-column normalisation modes; see :meth:`cluster_embedding`.
         feature_weights : dict[str, float] | None
             Substring → weight mapping, e.g. ``{"speed": 4.0}``.
-            Resolved internally into per-column weights.  Raises if a
-            rule matches no column (likely typo).
         missing_policy : {"drop", "impute_weight"}
             How to handle NaN rows.
         chunk_size : int
@@ -503,7 +523,7 @@ class FeaturesCollection(BaseCollection):
         ...     f.store(s, 'counter')
         >>> batch, centroids, norm = fc.cluster_embedding_stream(
         ...     {'counter': [0]}, n_clusters=2)
-        >>> isinstance(centroids, pd.DataFrame) and centroids.shape[0] == 2
+        >>> hasattr(centroids, 'columns') and centroids.shape[0] == 2
         True
 
         ```
@@ -513,13 +533,15 @@ class FeaturesCollection(BaseCollection):
             n_clusters=n_clusters,
             random_state=random_state,
             normalize=normalize,
+            normalize_details=normalize_details,
             feature_weights=feature_weights,
             missing_policy=missing_policy,
             chunk_size=chunk_size,
             n_epochs=n_epochs,
             batch_size=batch_size,
         )
-        result_dict, centroids, scaling_factors, _meta = pipeline.run(self, embedding_dict, cfg)
+        result_dict, centroids_df, scaling_factors, meta = pipeline.run(self, embedding_dict, cfg)
+        centroids = CentroidsDf(df=centroids_df, scaling_recipe=meta["scaling_recipe"])
         return BatchResult(result_dict, self), centroids, scaling_factors
 
     def cluster_diagnostics(

--- a/src/py3r/behaviour/features/features_collection.py
+++ b/src/py3r/behaviour/features/features_collection.py
@@ -5,12 +5,11 @@ from typing import TYPE_CHECKING, Literal
 import numpy as np
 import pandas as pd
 
-from py3r.behaviour.features.cluster_pipeline import ClusteringConfig, ClusteringPipeline
+from py3r.behaviour.features.cluster_pipeline import ClusteringConfig, fit_cluster_embedding
 from py3r.behaviour.features.features import Features
 from py3r.behaviour.tracking.tracking_collection import TrackingCollection
 from py3r.behaviour.util.base_collection import BaseCollection
 from py3r.behaviour.util.collection_utils import (
-    BatchResult,
     _Indexer,
     resolve_single_store_name,
 )
@@ -368,13 +367,12 @@ class FeaturesCollection(BaseCollection):
         combined DataFrame, so memory usage scales with the largest single
         recording rather than the whole collection.
 
-        Returns ``(BatchResult, centroids, scaling_factors)`` where *centroids*
-        is a :class:`~py3r.behaviour.features.centroids_df.CentroidsDf`
-        carrying a ``scaling_recipe`` (embedding, normalisation flags, constant
-        factors, imputation means) needed to reproduce the transform on future
-        datasets.  *scaling_factors* is the constant part of the transform
-        (weights + global normalisation; per-recording stds for
-        ``"individual"`` columns are captured in the recipe, not here).
+        Returns ``(BatchResult, centroids)`` where *centroids* is a
+        :class:`~py3r.behaviour.features.centroids_df.CentroidsDf` carrying a
+        ``scaling_recipe`` (embedding, normalisation flags, constant factors,
+        imputation means) — everything needed to reproduce the transform on
+        future datasets via
+        :meth:`~py3r.behaviour.features.features.Features.assign_clusters_by_centroids`.
 
         **Algorithm note** — this method uses ``MiniBatchKMeans`` (stochastic
         online updates), which replaced the full-batch ``KMeans`` (Lloyd's
@@ -446,14 +444,13 @@ class FeaturesCollection(BaseCollection):
         >>> for f in fc.values():
         ...     s = pd.Series(range(len(f.tracking.data)), index=f.tracking.data.index)
         ...     f.store(s, 'counter')
-        >>> batch, centroids, norm = fc.cluster_embedding_stream(
+        >>> batch, centroids = fc.cluster_embedding_stream(
         ...     {'counter': [0]}, n_clusters=2)
         >>> hasattr(centroids, 'columns') and centroids.shape[0] == 2
         True
 
         ```
         """
-        pipeline = ClusteringPipeline()
         cfg = ClusteringConfig(
             n_clusters=n_clusters,
             random_state=random_state,
@@ -465,8 +462,9 @@ class FeaturesCollection(BaseCollection):
             n_epochs=n_epochs,
             batch_size=batch_size,
         )
-        result_dict, centroids, scaling_factors, _meta = pipeline.run(self, embedding_dict, cfg)
-        return BatchResult(result_dict, self), centroids, scaling_factors
+        centroids = fit_cluster_embedding(self, embedding_dict, cfg)
+        batch = self.each.assign_clusters_by_centroids(centroids)
+        return batch, centroids
 
     def cluster_diagnostics(
         self,

--- a/src/py3r/behaviour/features/features_collection.py
+++ b/src/py3r/behaviour/features/features_collection.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Literal
 import numpy as np
 import pandas as pd
 
-from py3r.behaviour.features.centroids_df import CentroidsDf
 from py3r.behaviour.features.cluster_pipeline import (
     ClusteringConfig,
     ClusteringPipeline,
@@ -449,8 +448,7 @@ class FeaturesCollection(BaseCollection):
             custom_scaling=custom_scaling,
             missing_policy=missing_policy,
         )
-        result_dict, centroids_df, scaling_factors, meta = pipeline.run(self, embedding_dict, cfg)
-        centroids = CentroidsDf(df=centroids_df, scaling_recipe=meta["scaling_recipe"])
+        result_dict, centroids, scaling_factors, _meta = pipeline.run(self, embedding_dict, cfg)
         return BatchResult(result_dict, self), centroids, scaling_factors
 
     def cluster_embedding_stream(
@@ -540,8 +538,7 @@ class FeaturesCollection(BaseCollection):
             n_epochs=n_epochs,
             batch_size=batch_size,
         )
-        result_dict, centroids_df, scaling_factors, meta = pipeline.run(self, embedding_dict, cfg)
-        centroids = CentroidsDf(df=centroids_df, scaling_recipe=meta["scaling_recipe"])
+        result_dict, centroids, scaling_factors, _meta = pipeline.run(self, embedding_dict, cfg)
         return BatchResult(result_dict, self), centroids, scaling_factors
 
     def cluster_diagnostics(

--- a/tests/oft_pipeline/oft_pipeline.py
+++ b/tests/oft_pipeline/oft_pipeline.py
@@ -442,21 +442,22 @@ fc[0].list_boundaries()
 #
 # Embed the feature time-series with temporal offsets, then cluster the embedded
 # space with streaming MiniBatchKMeans.
-# Returns `(cluster_labels, centroids, scaling_factors)`, where:
+# Returns `(cluster_labels, centroids)`, where:
 # - `cluster_labels` is a per-handle `BatchResult` of label series
-# - `centroids` is a DataFrame with `n_clusters` rows
+# - `centroids` is a `CentroidsDf` with `n_clusters` rows; its `scaling_recipe`
+#   captures the full transform (embedding, normalisation, imputation means) so
+#   that `assign_clusters_by_centroids` can reproduce it exactly on new data
 #
 # `cluster_embedding_stream` processes one `Features` at a time in multiple epochs
 # so it never materialises a combined DataFrame — use this for any multi-recording
-# dataset. `cluster_embedding` (in-memory k-means) is available for small datasets.
-# Both methods support `normalize` and `feature_weights` for advanced runs.
+# dataset. Supports `normalize`, `normalize_details`, and `feature_weights`.
 
 # %%
 cluster_features = list(set(fc[0].data.columns) - set(non_bfa_feats))
 offset = list(np.arange(-15, 16, 1))
 embedding_dict = {f: offset for f in cluster_features}
 
-cluster_labels, centroids, _ = fc.cluster_embedding_stream(
+cluster_labels, centroids = fc.cluster_embedding_stream(
     embedding_dict=embedding_dict, n_clusters=N_CLUSTERS
 )
 cluster_labels.store("kmeans_25", overwrite=True)

--- a/tests/test_featurescollection_clustering.py
+++ b/tests/test_featurescollection_clustering.py
@@ -21,6 +21,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from py3r.behaviour.features.centroids_df import CentroidsDf
 from py3r.behaviour.features.features import Features
 from py3r.behaviour.features.features_collection import FeaturesCollection
 from py3r.behaviour.tracking.tracking import Tracking
@@ -98,9 +99,10 @@ def _make_fc(
     return fc, embedding_dict
 
 
-def _sort_centroids(cents: pd.DataFrame) -> pd.DataFrame:
+def _sort_centroids(cents) -> pd.DataFrame:
     """Sort centroid rows for order-independent comparison."""
-    return cents.sort_values(by=list(cents.columns)).reset_index(drop=True)
+    df = cents.to_df() if isinstance(cents, CentroidsDf) else cents
+    return df.sort_values(by=list(df.columns)).reset_index(drop=True)
 
 
 def _label_agreement_permutation_invariant(lab_a: pd.Series, lab_b: pd.Series) -> float:
@@ -583,3 +585,194 @@ class TestEdgeCases:
             batch_size=16,
         )
         assert len(result) == len(feat.data)
+
+
+# ---------------------------------------------------------------------------
+# CentroidsDf wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestCentroidsDf:
+    @pytest.fixture()
+    def setup(self):
+        fc, emb = _make_fc(
+            n_objects=2, n_frames=100, inject_nans=False, add_constant_feature=False, seed=21
+        )
+        batch, centroids, sf = fc.cluster_embedding(
+            emb, n_clusters=3, random_state=0, normalize=True
+        )
+        return fc, emb, batch, centroids, sf
+
+    def test_centroids_is_centroidsdf(self, setup):
+        _, _, _, centroids, _ = setup
+        assert isinstance(centroids, CentroidsDf)
+
+    def test_dataframe_delegation(self, setup):
+        _, _, _, centroids, _ = setup
+        assert hasattr(centroids, "columns")
+        assert hasattr(centroids, "shape")
+        assert centroids.shape[0] == 3
+        assert np.all(np.isfinite(centroids.values))
+
+    def test_scaling_recipe_present(self, setup):
+        _, emb, _, centroids, _ = setup
+        recipe = centroids.scaling_recipe
+        assert "version" in recipe
+        assert "embedding_dict" in recipe
+        assert "columns" in recipe
+        assert "normalize_individual_base" in recipe
+        assert "constant_factors" in recipe
+        assert recipe["embedding_dict"] == emb
+
+    def test_save_load_roundtrip(self, setup, tmp_path):
+        _, emb, _, centroids, _ = setup
+        centroids.save(tmp_path / "run/")
+        loaded = CentroidsDf.load(tmp_path / "run/")
+        pd.testing.assert_frame_equal(centroids.to_df(), loaded.to_df())
+        assert loaded.scaling_recipe == centroids.scaling_recipe
+
+    def test_assign_via_recipe_matches_scaling_factors(self, setup):
+        """Recipe-based assign on the same data should match scaling_factors assign."""
+        fc, emb, _, centroids, sf = setup
+        feat = fc[list(fc.keys())[0]]
+        # Via recipe (CentroidsDf)
+        result_recipe = feat.assign_clusters_by_centroids(emb, centroids)
+        # Via legacy scaling_factors (plain DF)
+        result_sf = feat.assign_clusters_by_centroids(emb, centroids.to_df(), scaling_factors=sf)
+        pd.testing.assert_series_equal(
+            pd.Series(result_recipe).astype("Int64"),
+            pd.Series(result_sf).astype("Int64"),
+        )
+
+    def test_stream_returns_centroidsdf(self):
+        fc, emb = _make_fc(
+            n_objects=2, n_frames=80, inject_nans=False, add_constant_feature=False, seed=22
+        )
+        _, centroids, _ = fc.cluster_embedding_stream(
+            emb, n_clusters=2, random_state=0, normalize=True, n_epochs=2
+        )
+        assert isinstance(centroids, CentroidsDf)
+        assert "scaling_recipe" in dir(centroids) or hasattr(centroids, "scaling_recipe")
+
+
+# ---------------------------------------------------------------------------
+# normalize_details parameter
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeDetails:
+    @pytest.fixture()
+    def fc_and_emb(self):
+        return _make_fc(
+            n_objects=3, n_frames=150, inject_nans=False, add_constant_feature=False, seed=55
+        )
+
+    def test_all_global_matches_normalize_true(self, fc_and_emb):
+        """normalize_details={'speed':'global','accel':'global'} == normalize=True."""
+        fc, emb = fc_and_emb
+        _, cents_norm, sf_norm = fc.cluster_embedding(
+            emb, n_clusters=2, random_state=0, normalize=True
+        )
+        _, cents_det, sf_det = fc.cluster_embedding(
+            emb,
+            n_clusters=2,
+            random_state=0,
+            normalize_details={"speed": "global", "accel": "global"},
+        )
+        pd.testing.assert_frame_equal(
+            _sort_centroids(cents_norm).astype(np.float64),
+            _sort_centroids(cents_det).astype(np.float64),
+        )
+
+    def test_all_none_matches_no_normalization(self, fc_and_emb):
+        """normalize_details={'speed':'none','accel':'none'} == no normalization."""
+        fc, emb = fc_and_emb
+        _, cents_plain, _ = fc.cluster_embedding(emb, n_clusters=2, random_state=0)
+        _, cents_none, _ = fc.cluster_embedding(
+            emb,
+            n_clusters=2,
+            random_state=0,
+            normalize_details={"speed": "none", "accel": "none"},
+        )
+        pd.testing.assert_frame_equal(
+            _sort_centroids(cents_plain).astype(np.float64),
+            _sort_centroids(cents_none).astype(np.float64),
+        )
+
+    def test_individual_mode_recipe_captured(self, fc_and_emb):
+        """Individual mode columns appear in normalize_individual_base=True in recipe."""
+        fc, emb = fc_and_emb
+        _, centroids, _ = fc.cluster_embedding(
+            emb,
+            n_clusters=2,
+            random_state=0,
+            normalize_details={"speed": "individual", "accel": "global"},
+        )
+        recipe = centroids.scaling_recipe
+        assert recipe["normalize_individual_base"]["speed"] is True
+        assert recipe["normalize_individual_base"]["accel"] is False
+
+    def test_individual_mode_constant_factors_excludes_individual_std(self, fc_and_emb):
+        """scaling_factors should not include the per-recording std for individual cols."""
+        fc, emb = fc_and_emb
+        _, _, sf = fc.cluster_embedding(
+            emb,
+            n_clusters=2,
+            random_state=0,
+            normalize_details={"speed": "individual", "accel": "global"},
+        )
+        # Speed columns get weight 1.0 (no weight) and no global std applied,
+        # so their constant factor should be 1.0.
+        for col in sf or {}:
+            if col.startswith("speed"):
+                assert sf[col] == pytest.approx(1.0), (
+                    f"Expected constant=1.0 for individual column {col}, got {sf[col]}"
+                )
+
+    def test_overlap_rule_raises(self, fc_and_emb):
+        fc, emb = fc_and_emb
+        with pytest.raises(ValueError, match="overlap"):
+            fc.cluster_embedding(
+                emb,
+                n_clusters=2,
+                normalize_details={"speed": "global", "peed": "individual"},
+            )
+
+    def test_unmatched_rule_raises(self, fc_and_emb):
+        fc, emb = fc_and_emb
+        with pytest.raises(ValueError, match="matched no columns"):
+            fc.cluster_embedding(
+                emb,
+                n_clusters=2,
+                normalize_details={"typo_col": "global"},
+            )
+
+    def test_stream_individual_mode(self, fc_and_emb):
+        """Streaming path supports normalize_details with individual mode."""
+        fc, emb = fc_and_emb
+        _, centroids, sf = fc.cluster_embedding_stream(
+            emb,
+            n_clusters=2,
+            random_state=0,
+            normalize_details={"speed": "individual", "accel": "global"},
+            n_epochs=3,
+        )
+        assert isinstance(centroids, CentroidsDf)
+        recipe = centroids.scaling_recipe
+        assert recipe["normalize_individual_base"]["speed"] is True
+        assert recipe["normalize_individual_base"]["accel"] is False
+
+    def test_assign_via_recipe_individual(self, fc_and_emb):
+        """After fitting with individual mode, recipe-based assign works on new Features."""
+        fc, emb = fc_and_emb
+        _, centroids, _ = fc.cluster_embedding(
+            emb,
+            n_clusters=2,
+            random_state=0,
+            normalize_details={"speed": "individual", "accel": "global"},
+        )
+        feat = fc[list(fc.keys())[0]]
+        result = feat.assign_clusters_by_centroids(emb, centroids)
+        labels = pd.Series(result)
+        assert len(labels) == len(feat.data)
+        assert labels.notna().any()

--- a/tests/test_featurescollection_clustering.py
+++ b/tests/test_featurescollection_clustering.py
@@ -2,8 +2,7 @@
 Tests for the clustering API on FeaturesCollection.
 
 Checks:
-  - cluster_embedding_stream is the canonical path; cluster_embedding is a
-    deprecated shim that delegates to it.
+  - cluster_embedding_stream is the canonical path; cluster_embedding is gone.
   - normalize, feature_weights, normalize_details all work correctly.
   - CentroidsDf wrapper: delegation, scaling_recipe, save/load roundtrip.
   - Edge cases: NaNs in features, constant features, impute_weight policy.
@@ -102,26 +101,6 @@ def _sort_centroids(cents) -> pd.DataFrame:
     return df.sort_values(by=list(df.columns)).reset_index(drop=True)
 
 
-def _label_agreement_permutation_invariant(lab_a: pd.Series, lab_b: pd.Series) -> float:
-    """
-    Best-case label agreement over all permutations of cluster IDs.
-
-    For k clusters this is O(k!) — fine for small k in tests.
-    """
-    from itertools import permutations
-
-    common = lab_a.index.intersection(lab_b.index)
-    a, b = lab_a[common].values, lab_b[common].values
-    unique_ids = np.unique(np.concatenate([a, b]))
-    best = 0.0
-    for perm in permutations(unique_ids):
-        mapping = dict(zip(unique_ids, perm, strict=True))
-        remapped = np.array([mapping[v] for v in b])
-        agreement = (a == remapped).mean()
-        best = max(best, agreement)
-    return best
-
-
 # ---------------------------------------------------------------------------
 # build_column_weights
 # ---------------------------------------------------------------------------
@@ -166,21 +145,15 @@ class TestFeatureWeights:
         fc, emb = fc_and_embedding
         rules = {"speed": 3.0}
 
-        batch_rules, cents_rules, sf_rules = fc.cluster_embedding_stream(
-            emb,
-            n_clusters=2,
-            random_state=0,
-            feature_weights=rules,
+        batch_rules, cents_rules = fc.cluster_embedding_stream(
+            emb, n_clusters=2, random_state=0, feature_weights=rules
         )
 
         first_feat = next(iter(fc.features_dict.values()))
         cols = first_feat.embedding_df(emb).columns
         explicit = build_column_weights(cols, rules)
-        batch_cw, cents_cw, sf_cw = fc.cluster_embedding_stream(
-            emb,
-            n_clusters=2,
-            random_state=0,
-            feature_weights=explicit,
+        batch_cw, cents_cw = fc.cluster_embedding_stream(
+            emb, n_clusters=2, random_state=0, feature_weights=explicit
         )
 
         pd.testing.assert_frame_equal(
@@ -193,10 +166,10 @@ class TestFeatureWeights:
                 pd.Series(batch_cw[key]),
             )
 
-    def test_feature_weights_stream(self, fc_and_embedding):
+    def test_feature_weights_small_chunks(self, fc_and_embedding):
         """feature_weights should work correctly with small chunk/batch sizes."""
         fc, emb = fc_and_embedding
-        batch, cents, sf = fc.cluster_embedding_stream(
+        batch, cents = fc.cluster_embedding_stream(
             emb,
             n_clusters=2,
             random_state=0,
@@ -212,15 +185,11 @@ class TestFeatureWeights:
     def test_typo_in_rule_raises(self, fc_and_embedding):
         fc, emb = fc_and_embedding
         with pytest.raises(ValueError, match="matched no columns"):
-            fc.cluster_embedding_stream(
-                emb,
-                n_clusters=2,
-                feature_weights={"speeed": 3.0},
-            )
+            fc.cluster_embedding_stream(emb, n_clusters=2, feature_weights={"speeed": 3.0})
 
 
 # ---------------------------------------------------------------------------
-# Deprecated / removed params
+# cluster_embedding removed
 # ---------------------------------------------------------------------------
 
 
@@ -245,7 +214,7 @@ class TestRemovedClusterEmbedding:
 
 
 # ---------------------------------------------------------------------------
-# assign_clusters_by_centroids: new vs deprecated
+# assign_clusters_by_centroids
 # ---------------------------------------------------------------------------
 
 
@@ -256,41 +225,38 @@ class TestAssignClusters:
             n_objects=1, n_frames=100, inject_nans=False, add_constant_feature=False, seed=11
         )
         feat = fc[list(fc.keys())[0]]
-        _, cents, sf = fc.cluster_embedding_stream(
-            emb,
-            n_clusters=3,
-            random_state=0,
-            normalize=True,
-        )
-        return feat, emb, cents, sf
-
-    def test_new_scaling_factors_param(self, setup):
-        feat, emb, cents, sf = setup
-        result = feat.assign_clusters_by_centroids(cents, emb, scaling_factors=sf)
-        assert len(result) == len(feat.data)
-        assert pd.Series(result).notna().sum() > 0
+        _, cents = fc.cluster_embedding_stream(emb, n_clusters=3, random_state=0, normalize=True)
+        return feat, emb, cents
 
     def test_centroidsdf_no_embedding_needed(self, setup):
-        feat, emb, cents, _ = setup
-        # CentroidsDf carries embedding in recipe — no need to pass it
+        """CentroidsDf carries embedding in recipe — no need to pass it."""
+        feat, emb, cents = setup
         result = feat.assign_clusters_by_centroids(cents)
         assert len(result) == len(feat.data)
         assert pd.Series(result).notna().sum() > 0
 
+    def test_legacy_scaling_factors_path(self, setup):
+        """Plain DataFrame + scaling_factors from recipe should still work."""
+        feat, emb, cents = setup
+        sf = cents.scaling_recipe.get("constant_factors") or {}
+        result = feat.assign_clusters_by_centroids(cents.to_df(), emb, scaling_factors=sf or None)
+        assert len(result) == len(feat.data)
+        assert pd.Series(result).notna().sum() > 0
+
     def test_plain_df_requires_embedding(self, setup):
-        feat, emb, cents, _ = setup
+        feat, emb, cents = setup
         with pytest.raises(ValueError, match="embedding is required"):
             feat.assign_clusters_by_centroids(cents.to_df())
 
     def test_removed_rescale_factors_raises(self, setup):
-        feat, emb, cents, sf = setup
+        feat, emb, cents = setup
         embed_cols = feat.embedding_df(emb).columns
         rf = {c: 1.0 for c in embed_cols}
         with pytest.raises(NotImplementedError, match="rescale_factors"):
             feat.assign_clusters_by_centroids(cents, emb, rescale_factors=rf)
 
     def test_removed_custom_scaling_raises(self, setup):
-        feat, emb, cents, _ = setup
+        feat, emb, cents = setup
         with pytest.raises(NotImplementedError, match="custom_scaling"):
             feat.assign_clusters_by_centroids(
                 cents,
@@ -310,13 +276,8 @@ class TestEdgeCases:
         fc, emb = _make_fc(
             n_objects=2, n_frames=100, inject_nans=True, add_constant_feature=False, seed=55
         )
-        batch, cents, _ = fc.cluster_embedding_stream(
-            emb,
-            n_clusters=2,
-            random_state=0,
-            chunk_size=30,
-            n_epochs=3,
-            batch_size=16,
+        batch, cents = fc.cluster_embedding_stream(
+            emb, n_clusters=2, random_state=0, chunk_size=30, n_epochs=3, batch_size=16
         )
         for key in batch.keys():
             labels = pd.Series(batch[key])
@@ -328,7 +289,7 @@ class TestEdgeCases:
         fc, emb = _make_fc(
             n_objects=2, n_frames=100, inject_nans=False, add_constant_feature=True, seed=33
         )
-        batch, cents, sf = fc.cluster_embedding_stream(
+        batch, cents = fc.cluster_embedding_stream(
             emb,
             n_clusters=2,
             random_state=0,
@@ -337,10 +298,10 @@ class TestEdgeCases:
             n_epochs=3,
             batch_size=16,
         )
-        assert sf is not None
-        const_cols = [c for c in sf if c.startswith("const")]
+        recipe = cents.scaling_recipe
+        const_cols = [c for c in recipe["constant_factors"] if c.startswith("const")]
         for c in const_cols:
-            assert sf[c] == pytest.approx(1.0), f"Expected 1.0 for {c}, got {sf[c]}"
+            assert recipe["constant_factors"][c] == pytest.approx(1.0), f"Expected 1.0 for {c}"
         assert np.all(np.isfinite(cents.values))
 
     def test_impute_weight_policy(self):
@@ -348,7 +309,7 @@ class TestEdgeCases:
         fc, emb = _make_fc(
             n_objects=2, n_frames=100, inject_nans=True, add_constant_feature=False, seed=66
         )
-        batch, cents, _ = fc.cluster_embedding_stream(
+        batch, cents = fc.cluster_embedding_stream(
             emb,
             n_clusters=2,
             random_state=0,
@@ -367,13 +328,8 @@ class TestEdgeCases:
             n_objects=1, n_frames=80, inject_nans=False, add_constant_feature=False, seed=88
         )
         feat = fc[list(fc.keys())[0]]
-        result, cents, sf = feat.cluster_embedding_stream(
-            emb,
-            n_clusters=2,
-            random_state=0,
-            chunk_size=20,
-            n_epochs=5,
-            batch_size=16,
+        result, cents = feat.cluster_embedding_stream(
+            emb, n_clusters=2, random_state=0, chunk_size=20, n_epochs=5, batch_size=16
         )
         assert len(result) == len(feat.data)
 
@@ -389,24 +345,24 @@ class TestCentroidsDf:
         fc, emb = _make_fc(
             n_objects=2, n_frames=100, inject_nans=False, add_constant_feature=False, seed=21
         )
-        batch, centroids, sf = fc.cluster_embedding_stream(
+        batch, centroids = fc.cluster_embedding_stream(
             emb, n_clusters=3, random_state=0, normalize=True
         )
-        return fc, emb, batch, centroids, sf
+        return fc, emb, batch, centroids
 
     def test_centroids_is_centroidsdf(self, setup):
-        _, _, _, centroids, _ = setup
+        _, _, _, centroids = setup
         assert isinstance(centroids, CentroidsDf)
 
     def test_dataframe_delegation(self, setup):
-        _, _, _, centroids, _ = setup
+        _, _, _, centroids = setup
         assert hasattr(centroids, "columns")
         assert hasattr(centroids, "shape")
         assert centroids.shape[0] == 3
         assert np.all(np.isfinite(centroids.values))
 
     def test_scaling_recipe_present(self, setup):
-        _, emb, _, centroids, _ = setup
+        _, emb, _, centroids = setup
         recipe = centroids.scaling_recipe
         assert "version" in recipe
         assert "embedding_dict" in recipe
@@ -416,20 +372,21 @@ class TestCentroidsDf:
         assert recipe["embedding_dict"] == emb
 
     def test_save_load_roundtrip(self, setup, tmp_path):
-        _, emb, _, centroids, _ = setup
+        _, emb, _, centroids = setup
         centroids.save(tmp_path / "run/")
         loaded = CentroidsDf.load(tmp_path / "run/")
         pd.testing.assert_frame_equal(centroids.to_df(), loaded.to_df())
         assert loaded.scaling_recipe == centroids.scaling_recipe
 
-    def test_assign_via_recipe_matches_scaling_factors(self, setup):
-        """Recipe-based assign on the same data should match scaling_factors assign."""
-        fc, emb, _, centroids, sf = setup
+    def test_assign_via_recipe_matches_legacy_scaling_factors(self, setup):
+        """Recipe-based assign should match the legacy scaling_factors path."""
+        fc, emb, _, centroids = setup
         feat = fc[list(fc.keys())[0]]
-        # Via recipe (CentroidsDf) — embedding inferred from recipe
+        sf = centroids.scaling_recipe.get("constant_factors") or {}
         result_recipe = feat.assign_clusters_by_centroids(centroids)
-        # Via legacy scaling_factors (plain DF) — embedding must be provided
-        result_sf = feat.assign_clusters_by_centroids(centroids.to_df(), emb, scaling_factors=sf)
+        result_sf = feat.assign_clusters_by_centroids(
+            centroids.to_df(), emb, scaling_factors=sf or None
+        )
         pd.testing.assert_series_equal(
             pd.Series(result_recipe).astype("Int64"),
             pd.Series(result_sf).astype("Int64"),
@@ -451,10 +408,10 @@ class TestNormalizeDetails:
     def test_all_global_matches_normalize_true(self, fc_and_emb):
         """normalize_details={'speed':'global','accel':'global'} == normalize=True."""
         fc, emb = fc_and_emb
-        _, cents_norm, sf_norm = fc.cluster_embedding_stream(
+        _, cents_norm = fc.cluster_embedding_stream(
             emb, n_clusters=2, random_state=0, normalize=True
         )
-        _, cents_det, sf_det = fc.cluster_embedding_stream(
+        _, cents_det = fc.cluster_embedding_stream(
             emb,
             n_clusters=2,
             random_state=0,
@@ -468,12 +425,9 @@ class TestNormalizeDetails:
     def test_all_none_matches_no_normalization(self, fc_and_emb):
         """normalize_details={'speed':'none','accel':'none'} == no normalization."""
         fc, emb = fc_and_emb
-        _, cents_plain, _ = fc.cluster_embedding_stream(emb, n_clusters=2, random_state=0)
-        _, cents_none, _ = fc.cluster_embedding_stream(
-            emb,
-            n_clusters=2,
-            random_state=0,
-            normalize_details={"speed": "none", "accel": "none"},
+        _, cents_plain = fc.cluster_embedding_stream(emb, n_clusters=2, random_state=0)
+        _, cents_none = fc.cluster_embedding_stream(
+            emb, n_clusters=2, random_state=0, normalize_details={"speed": "none", "accel": "none"}
         )
         pd.testing.assert_frame_equal(
             _sort_centroids(cents_plain).astype(np.float64),
@@ -483,7 +437,7 @@ class TestNormalizeDetails:
     def test_individual_mode_recipe_captured(self, fc_and_emb):
         """Individual mode columns appear in normalize_individual_base=True in recipe."""
         fc, emb = fc_and_emb
-        _, centroids, _ = fc.cluster_embedding_stream(
+        _, centroids = fc.cluster_embedding_stream(
             emb,
             n_clusters=2,
             random_state=0,
@@ -494,59 +448,37 @@ class TestNormalizeDetails:
         assert recipe["normalize_individual_base"]["accel"] is False
 
     def test_individual_mode_constant_factors_excludes_individual_std(self, fc_and_emb):
-        """scaling_factors should not include the per-recording std for individual cols."""
+        """constant_factors should be 1.0 for individual columns (no global std applied)."""
         fc, emb = fc_and_emb
-        _, _, sf = fc.cluster_embedding_stream(
+        _, centroids = fc.cluster_embedding_stream(
             emb,
             n_clusters=2,
             random_state=0,
             normalize_details={"speed": "individual", "accel": "global"},
         )
-        # Speed columns get weight 1.0 (no weight) and no global std applied,
-        # so their constant factor should be 1.0.
-        for col in sf or {}:
+        cf = centroids.scaling_recipe.get("constant_factors") or {}
+        for col, factor in cf.items():
             if col.startswith("speed"):
-                assert sf[col] == pytest.approx(1.0), (
-                    f"Expected constant=1.0 for individual column {col}, got {sf[col]}"
+                assert factor == pytest.approx(1.0), (
+                    f"Expected constant=1.0 for individual column {col}, got {factor}"
                 )
 
     def test_overlap_rule_raises(self, fc_and_emb):
         fc, emb = fc_and_emb
         with pytest.raises(ValueError, match="overlap"):
             fc.cluster_embedding_stream(
-                emb,
-                n_clusters=2,
-                normalize_details={"speed": "global", "peed": "individual"},
+                emb, n_clusters=2, normalize_details={"speed": "global", "peed": "individual"}
             )
 
     def test_unmatched_rule_raises(self, fc_and_emb):
         fc, emb = fc_and_emb
         with pytest.raises(ValueError, match="matched no columns"):
-            fc.cluster_embedding_stream(
-                emb,
-                n_clusters=2,
-                normalize_details={"typo_col": "global"},
-            )
-
-    def test_individual_mode_recipe_captured_stream(self, fc_and_emb):
-        """normalize_details with individual mode is captured correctly in recipe."""
-        fc, emb = fc_and_emb
-        _, centroids, sf = fc.cluster_embedding_stream(
-            emb,
-            n_clusters=2,
-            random_state=0,
-            normalize_details={"speed": "individual", "accel": "global"},
-            n_epochs=3,
-        )
-        assert isinstance(centroids, CentroidsDf)
-        recipe = centroids.scaling_recipe
-        assert recipe["normalize_individual_base"]["speed"] is True
-        assert recipe["normalize_individual_base"]["accel"] is False
+            fc.cluster_embedding_stream(emb, n_clusters=2, normalize_details={"typo_col": "global"})
 
     def test_assign_via_recipe_individual(self, fc_and_emb):
         """After fitting with individual mode, recipe-based assign works on new Features."""
         fc, emb = fc_and_emb
-        _, centroids, _ = fc.cluster_embedding_stream(
+        _, centroids = fc.cluster_embedding_stream(
             emb,
             n_clusters=2,
             random_state=0,

--- a/tests/test_featurescollection_clustering.py
+++ b/tests/test_featurescollection_clustering.py
@@ -2,14 +2,11 @@
 Tests for the clustering API on FeaturesCollection.
 
 Checks:
-  - New pathway (normalize, feature_weights) vs deprecated pathway
-    (auto_normalize, rescale_factors, custom_scaling) produce identical
-    results.
-  - Streaming pathway (cluster_embedding_stream) vs standard pathway
-    (cluster_embedding) produce equivalent results when configured
-    comparably.
-  - Edge cases: NaNs in features, single-row features, all-constant
-    features.
+  - cluster_embedding_stream is the canonical path; cluster_embedding is a
+    deprecated shim that delegates to it.
+  - normalize, feature_weights, normalize_details all work correctly.
+  - CentroidsDf wrapper: delegation, scaling_recipe, save/load roundtrip.
+  - Edge cases: NaNs in features, constant features, impute_weight policy.
   - build_column_weights utility correctness.
 """
 
@@ -169,7 +166,7 @@ class TestFeatureWeights:
         fc, emb = fc_and_embedding
         rules = {"speed": 3.0}
 
-        batch_rules, cents_rules, sf_rules = fc.cluster_embedding(
+        batch_rules, cents_rules, sf_rules = fc.cluster_embedding_stream(
             emb,
             n_clusters=2,
             random_state=0,
@@ -179,7 +176,7 @@ class TestFeatureWeights:
         first_feat = next(iter(fc.features_dict.values()))
         cols = first_feat.embedding_df(emb).columns
         explicit = build_column_weights(cols, rules)
-        batch_cw, cents_cw, sf_cw = fc.cluster_embedding(
+        batch_cw, cents_cw, sf_cw = fc.cluster_embedding_stream(
             emb,
             n_clusters=2,
             random_state=0,
@@ -197,7 +194,7 @@ class TestFeatureWeights:
             )
 
     def test_feature_weights_stream(self, fc_and_embedding):
-        """feature_weights should work on the streaming path too."""
+        """feature_weights should work correctly with small chunk/batch sizes."""
         fc, emb = fc_and_embedding
         batch, cents, sf = fc.cluster_embedding_stream(
             emb,
@@ -215,7 +212,7 @@ class TestFeatureWeights:
     def test_typo_in_rule_raises(self, fc_and_embedding):
         fc, emb = fc_and_embedding
         with pytest.raises(ValueError, match="matched no columns"):
-            fc.cluster_embedding(
+            fc.cluster_embedding_stream(
                 emb,
                 n_clusters=2,
                 feature_weights={"speeed": 3.0},
@@ -223,187 +220,28 @@ class TestFeatureWeights:
 
 
 # ---------------------------------------------------------------------------
-# Removed deprecated params
+# Deprecated / removed params
 # ---------------------------------------------------------------------------
 
 
-class TestRemovedLegacyClusterParams:
+class TestRemovedClusterEmbedding:
     @pytest.fixture()
     def fc_and_embedding(self):
         return _make_fc(
             n_objects=3, n_frames=200, inject_nans=False, add_constant_feature=False, seed=99
         )
 
-    def test_auto_normalize_removed(self, fc_and_embedding):
+    def test_cluster_embedding_removed(self, fc_and_embedding):
+        """cluster_embedding was removed in 3.3.0 and always raises."""
         fc, emb = fc_and_embedding
-        with pytest.raises(NotImplementedError, match="auto_normalize"):
-            fc.cluster_embedding(emb, n_clusters=3, auto_normalize=True)
+        with pytest.raises(NotImplementedError, match="3.3.0"):
+            fc.cluster_embedding(emb, n_clusters=3)
 
-    def test_rescale_factors_removed(self, fc_and_embedding):
+    def test_cluster_embedding_removed_regardless_of_args(self, fc_and_embedding):
+        """Passes any combination of args — should still raise immediately."""
         fc, emb = fc_and_embedding
-        with pytest.raises(NotImplementedError, match="rescale_factors"):
-            fc.cluster_embedding(emb, n_clusters=3, rescale_factors={"speed_t0": 1.0})
-
-    def test_custom_scaling_removed(self, fc_and_embedding):
-        fc, emb = fc_and_embedding
-        with pytest.raises(NotImplementedError, match="custom_scaling"):
-            fc.cluster_embedding(
-                emb,
-                n_clusters=3,
-                custom_scaling={"speed": {"scale": 1.0}},
-            )
-
-    def test_new_and_removed_params_combination_also_fails(self, fc_and_embedding):
-        fc, emb = fc_and_embedding
-        with pytest.raises(NotImplementedError, match="auto_normalize"):
-            fc.cluster_embedding(
-                emb,
-                n_clusters=3,
-                normalize=True,
-                auto_normalize=True,
-            )
-
-
-# ---------------------------------------------------------------------------
-# Streaming pathway vs standard pathway
-# ---------------------------------------------------------------------------
-
-
-def _make_separable_fc(seed: int = 42):
-    """
-    Build a FeaturesCollection where the data has 2 obvious clusters:
-      - first half of each recording: speed ~ N(0.0, 0.02), accel ~ N(0.0, 0.02)
-      - second half:                  speed ~ N(5.0, 0.02), accel ~ N(5.0, 0.02)
-
-    With such clear separation, both KMeans and MiniBatchKMeans must agree.
-    """
-    rng = np.random.default_rng(seed)
-    feats_list: list[Features] = []
-    n_frames = 200
-    for i in range(2):
-        t = _make_tracking(f"rec_{i}", n_frames, seed=seed + i)
-        f = Features(t)
-        half = n_frames // 2
-        speed_vals = np.concatenate(
-            [
-                rng.standard_normal(half) * 0.02,
-                rng.standard_normal(half) * 0.02 + 5.0,
-            ]
-        )
-        accel_vals = np.concatenate(
-            [
-                rng.standard_normal(half) * 0.02,
-                rng.standard_normal(half) * 0.02 + 5.0,
-            ]
-        )
-        f.store(pd.Series(speed_vals, index=t.data.index), "speed")
-        f.store(pd.Series(accel_vals, index=t.data.index), "accel")
-        feats_list.append(f)
-
-    fc = FeaturesCollection.from_list(feats_list)
-    emb = {"speed": [0], "accel": [0]}
-    return fc, emb
-
-
-class TestStreamVsStandard:
-    """
-    On well-separated data (2 obvious clusters) both KMeans and
-    MiniBatchKMeans must converge to the same partition.
-    """
-
-    @pytest.fixture()
-    def fc_and_embedding(self):
-        return _make_separable_fc(seed=77)
-
-    def test_labels_agree_no_scaling(self, fc_and_embedding):
-        fc, emb = fc_and_embedding
-        batch_std, _, _ = fc.cluster_embedding(
-            emb,
-            n_clusters=2,
-            random_state=0,
-            lowmem=True,
-            decimation_factor=1,
-        )
-        batch_str, _, _ = fc.cluster_embedding_stream(
-            emb,
-            n_clusters=2,
-            random_state=0,
-            chunk_size=50,
-            n_epochs=10,
-            batch_size=32,
-        )
-
-        for key in batch_std.keys():
-            lab_std = pd.Series(batch_std[key]).dropna()
-            lab_str = pd.Series(batch_str[key]).dropna()
-            agreement = _label_agreement_permutation_invariant(lab_std, lab_str)
-            assert agreement > 0.95, f"{key}: label agreement {agreement:.2%} < 95%"
-
-    def test_labels_agree_with_normalize(self, fc_and_embedding):
-        fc, emb = fc_and_embedding
-        batch_std, _, sf_std = fc.cluster_embedding(
-            emb,
-            n_clusters=2,
-            random_state=0,
-            lowmem=True,
-            decimation_factor=1,
-            normalize=True,
-        )
-        batch_str, _, sf_str = fc.cluster_embedding_stream(
-            emb,
-            n_clusters=2,
-            random_state=0,
-            normalize=True,
-            chunk_size=50,
-            n_epochs=10,
-            batch_size=32,
-        )
-
-        assert sf_std is not None and sf_str is not None
-        for col in sf_std:
-            np.testing.assert_allclose(
-                sf_std[col],
-                sf_str[col],
-                rtol=1e-4,
-                err_msg=f"Scaling mismatch on {col}",
-            )
-
-        for key in batch_std.keys():
-            lab_std = pd.Series(batch_std[key]).dropna()
-            lab_str = pd.Series(batch_str[key]).dropna()
-            agreement = _label_agreement_permutation_invariant(lab_std, lab_str)
-            assert agreement > 0.95, f"{key}: label agreement {agreement:.2%} < 95%"
-
-    def test_labels_agree_with_explicit_feature_weights(self, fc_and_embedding):
-        fc, emb = fc_and_embedding
-        first_feat = fc[list(fc.keys())[0]]
-        weights = build_column_weights(
-            list(first_feat.embedding_df(emb).columns),
-            {"speed": 3.0},
-        )
-        batch_std, _, _ = fc.cluster_embedding(
-            emb,
-            n_clusters=2,
-            random_state=0,
-            lowmem=True,
-            decimation_factor=1,
-            feature_weights=weights,
-        )
-        batch_str, _, _ = fc.cluster_embedding_stream(
-            emb,
-            n_clusters=2,
-            random_state=0,
-            feature_weights=weights,
-            chunk_size=50,
-            n_epochs=10,
-            batch_size=32,
-        )
-
-        for key in batch_std.keys():
-            lab_std = pd.Series(batch_std[key]).dropna()
-            lab_str = pd.Series(batch_str[key]).dropna()
-            agreement = _label_agreement_permutation_invariant(lab_std, lab_str)
-            assert agreement > 0.95, f"{key}: label agreement {agreement:.2%} < 95%"
+        with pytest.raises(NotImplementedError):
+            fc.cluster_embedding(emb, n_clusters=3, normalize=True)
 
 
 # ---------------------------------------------------------------------------
@@ -418,11 +256,10 @@ class TestAssignClusters:
             n_objects=1, n_frames=100, inject_nans=False, add_constant_feature=False, seed=11
         )
         feat = fc[list(fc.keys())[0]]
-        _, cents, sf = fc.cluster_embedding(
+        _, cents, sf = fc.cluster_embedding_stream(
             emb,
             n_clusters=3,
             random_state=0,
-            lowmem=True,
             normalize=True,
         )
         return feat, emb, cents, sf
@@ -447,7 +284,6 @@ class TestAssignClusters:
 
     def test_removed_rescale_factors_raises(self, setup):
         feat, emb, cents, sf = setup
-        # Build a valid rescale_factors dict covering all embedding columns
         embed_cols = feat.embedding_df(emb).columns
         rf = {c: 1.0 for c in embed_cols}
         with pytest.raises(NotImplementedError, match="rescale_factors"):
@@ -474,22 +310,6 @@ class TestEdgeCases:
         fc, emb = _make_fc(
             n_objects=2, n_frames=100, inject_nans=True, add_constant_feature=False, seed=55
         )
-        batch, cents, _ = fc.cluster_embedding(
-            emb,
-            n_clusters=2,
-            random_state=0,
-            lowmem=True,
-        )
-        for key in batch.keys():
-            labels = pd.Series(batch[key])
-            assert labels.isna().any(), "Expected some NA labels from NaN rows"
-            assert labels.notna().any(), "Expected some valid labels"
-
-    def test_nans_streaming(self):
-        """Streaming path should also handle NaNs gracefully."""
-        fc, emb = _make_fc(
-            n_objects=2, n_frames=100, inject_nans=True, add_constant_feature=False, seed=55
-        )
         batch, cents, _ = fc.cluster_embedding_stream(
             emb,
             n_clusters=2,
@@ -500,29 +320,11 @@ class TestEdgeCases:
         )
         for key in batch.keys():
             labels = pd.Series(batch[key])
-            assert labels.isna().any()
-            assert labels.notna().any()
+            assert labels.isna().any(), "Expected some NA labels from NaN rows"
+            assert labels.notna().any(), "Expected some valid labels"
 
     def test_constant_feature_normalize(self):
         """A constant feature has std=0; normalize should not produce inf."""
-        fc, emb = _make_fc(
-            n_objects=2, n_frames=100, inject_nans=False, add_constant_feature=True, seed=33
-        )
-        batch, cents, sf = fc.cluster_embedding(
-            emb,
-            n_clusters=2,
-            random_state=0,
-            lowmem=True,
-            normalize=True,
-        )
-        assert sf is not None
-        const_cols = [c for c in sf if c.startswith("const")]
-        for c in const_cols:
-            assert sf[c] == pytest.approx(1.0), f"Expected 1.0 for {c}, got {sf[c]}"
-        assert np.all(np.isfinite(cents.values))
-
-    def test_constant_feature_stream_normalize(self):
-        """Same zero-std safety check for the streaming path."""
         fc, emb = _make_fc(
             n_objects=2, n_frames=100, inject_nans=False, add_constant_feature=True, seed=33
         )
@@ -538,26 +340,11 @@ class TestEdgeCases:
         assert sf is not None
         const_cols = [c for c in sf if c.startswith("const")]
         for c in const_cols:
-            assert sf[c] == pytest.approx(1.0)
+            assert sf[c] == pytest.approx(1.0), f"Expected 1.0 for {c}, got {sf[c]}"
         assert np.all(np.isfinite(cents.values))
 
     def test_impute_weight_policy(self):
         """impute_weight should produce labels for all rows, even NaN ones."""
-        fc, emb = _make_fc(
-            n_objects=2, n_frames=100, inject_nans=True, add_constant_feature=False, seed=66
-        )
-        batch, cents, _ = fc.cluster_embedding(
-            emb,
-            n_clusters=2,
-            random_state=0,
-            lowmem=True,
-            missing_policy="impute_weight",
-        )
-        for key in batch.keys():
-            labels = pd.Series(batch[key])
-            assert labels.notna().all(), "impute_weight should fill all labels"
-
-    def test_impute_weight_stream(self):
         fc, emb = _make_fc(
             n_objects=2, n_frames=100, inject_nans=True, add_constant_feature=False, seed=66
         )
@@ -572,18 +359,10 @@ class TestEdgeCases:
         )
         for key in batch.keys():
             labels = pd.Series(batch[key])
-            assert labels.notna().all()
+            assert labels.notna().all(), "impute_weight should fill all labels"
 
     def test_single_features_object(self):
-        """Features.cluster_embedding should work on a single recording."""
-        fc, emb = _make_fc(
-            n_objects=1, n_frames=80, inject_nans=False, add_constant_feature=False, seed=88
-        )
-        feat = fc[list(fc.keys())[0]]
-        result, cents, sf = feat.cluster_embedding(emb, n_clusters=2, random_state=0)
-        assert len(result) == len(feat.data)
-
-    def test_single_features_stream(self):
+        """Features.cluster_embedding_stream should work on a single recording."""
         fc, emb = _make_fc(
             n_objects=1, n_frames=80, inject_nans=False, add_constant_feature=False, seed=88
         )
@@ -610,7 +389,7 @@ class TestCentroidsDf:
         fc, emb = _make_fc(
             n_objects=2, n_frames=100, inject_nans=False, add_constant_feature=False, seed=21
         )
-        batch, centroids, sf = fc.cluster_embedding(
+        batch, centroids, sf = fc.cluster_embedding_stream(
             emb, n_clusters=3, random_state=0, normalize=True
         )
         return fc, emb, batch, centroids, sf
@@ -656,16 +435,6 @@ class TestCentroidsDf:
             pd.Series(result_sf).astype("Int64"),
         )
 
-    def test_stream_returns_centroidsdf(self):
-        fc, emb = _make_fc(
-            n_objects=2, n_frames=80, inject_nans=False, add_constant_feature=False, seed=22
-        )
-        _, centroids, _ = fc.cluster_embedding_stream(
-            emb, n_clusters=2, random_state=0, normalize=True, n_epochs=2
-        )
-        assert isinstance(centroids, CentroidsDf)
-        assert "scaling_recipe" in dir(centroids) or hasattr(centroids, "scaling_recipe")
-
 
 # ---------------------------------------------------------------------------
 # normalize_details parameter
@@ -682,10 +451,10 @@ class TestNormalizeDetails:
     def test_all_global_matches_normalize_true(self, fc_and_emb):
         """normalize_details={'speed':'global','accel':'global'} == normalize=True."""
         fc, emb = fc_and_emb
-        _, cents_norm, sf_norm = fc.cluster_embedding(
+        _, cents_norm, sf_norm = fc.cluster_embedding_stream(
             emb, n_clusters=2, random_state=0, normalize=True
         )
-        _, cents_det, sf_det = fc.cluster_embedding(
+        _, cents_det, sf_det = fc.cluster_embedding_stream(
             emb,
             n_clusters=2,
             random_state=0,
@@ -699,8 +468,8 @@ class TestNormalizeDetails:
     def test_all_none_matches_no_normalization(self, fc_and_emb):
         """normalize_details={'speed':'none','accel':'none'} == no normalization."""
         fc, emb = fc_and_emb
-        _, cents_plain, _ = fc.cluster_embedding(emb, n_clusters=2, random_state=0)
-        _, cents_none, _ = fc.cluster_embedding(
+        _, cents_plain, _ = fc.cluster_embedding_stream(emb, n_clusters=2, random_state=0)
+        _, cents_none, _ = fc.cluster_embedding_stream(
             emb,
             n_clusters=2,
             random_state=0,
@@ -714,7 +483,7 @@ class TestNormalizeDetails:
     def test_individual_mode_recipe_captured(self, fc_and_emb):
         """Individual mode columns appear in normalize_individual_base=True in recipe."""
         fc, emb = fc_and_emb
-        _, centroids, _ = fc.cluster_embedding(
+        _, centroids, _ = fc.cluster_embedding_stream(
             emb,
             n_clusters=2,
             random_state=0,
@@ -727,7 +496,7 @@ class TestNormalizeDetails:
     def test_individual_mode_constant_factors_excludes_individual_std(self, fc_and_emb):
         """scaling_factors should not include the per-recording std for individual cols."""
         fc, emb = fc_and_emb
-        _, _, sf = fc.cluster_embedding(
+        _, _, sf = fc.cluster_embedding_stream(
             emb,
             n_clusters=2,
             random_state=0,
@@ -744,7 +513,7 @@ class TestNormalizeDetails:
     def test_overlap_rule_raises(self, fc_and_emb):
         fc, emb = fc_and_emb
         with pytest.raises(ValueError, match="overlap"):
-            fc.cluster_embedding(
+            fc.cluster_embedding_stream(
                 emb,
                 n_clusters=2,
                 normalize_details={"speed": "global", "peed": "individual"},
@@ -753,14 +522,14 @@ class TestNormalizeDetails:
     def test_unmatched_rule_raises(self, fc_and_emb):
         fc, emb = fc_and_emb
         with pytest.raises(ValueError, match="matched no columns"):
-            fc.cluster_embedding(
+            fc.cluster_embedding_stream(
                 emb,
                 n_clusters=2,
                 normalize_details={"typo_col": "global"},
             )
 
-    def test_stream_individual_mode(self, fc_and_emb):
-        """Streaming path supports normalize_details with individual mode."""
+    def test_individual_mode_recipe_captured_stream(self, fc_and_emb):
+        """normalize_details with individual mode is captured correctly in recipe."""
         fc, emb = fc_and_emb
         _, centroids, sf = fc.cluster_embedding_stream(
             emb,
@@ -777,7 +546,7 @@ class TestNormalizeDetails:
     def test_assign_via_recipe_individual(self, fc_and_emb):
         """After fitting with individual mode, recipe-based assign works on new Features."""
         fc, emb = fc_and_emb
-        _, centroids, _ = fc.cluster_embedding(
+        _, centroids, _ = fc.cluster_embedding_stream(
             emb,
             n_clusters=2,
             random_state=0,

--- a/tests/test_featurescollection_clustering.py
+++ b/tests/test_featurescollection_clustering.py
@@ -7,6 +7,7 @@ Checks:
   - CentroidsDf wrapper: delegation, scaling_recipe, save/load roundtrip.
   - Edge cases: NaNs in features, constant features, impute_weight policy.
   - build_column_weights utility correctness.
+  - assign_clusters_by_centroids allow_missing_features subspace assignment.
 """
 
 from __future__ import annotations
@@ -489,3 +490,284 @@ class TestNormalizeDetails:
         labels = pd.Series(result)
         assert len(labels) == len(feat.data)
         assert labels.notna().any()
+
+
+# ---------------------------------------------------------------------------
+# allow_missing_features subspace assignment
+# ---------------------------------------------------------------------------
+
+
+def _make_features_with(t, feature_names: list[str], *, seed: int) -> Features:
+    """Return a Features built on *t* with the given named features stored."""
+    rng = np.random.default_rng(seed)
+    n = len(t.data)
+    feat = Features(t)
+    for name in feature_names:
+        feat.store(pd.Series(rng.standard_normal(n) + 1.0, index=t.data.index), name)
+    return feat
+
+
+def _plain_cents(columns: list[str], n_clusters: int = 2) -> pd.DataFrame:
+    """Return a trivial centroid DataFrame with the given columns."""
+    rng = np.random.default_rng(0)
+    return pd.DataFrame(
+        rng.standard_normal((n_clusters, len(columns))),
+        columns=columns,
+    )
+
+
+class TestAssignClustersAllowMissingFeatures:
+    """
+    Tests for allow_missing_features in assign_clusters_by_centroids.
+
+    Topology used throughout
+    ------------------------
+    * feat_full   – Features with {speed, accel}
+    * feat_no_accel – Features with {speed} only (accel base column absent)
+    * emb_full    – {"speed": [0, 1], "accel": [0, 1]}
+    * emb_speed   – {"speed": [0, 1]}
+    * cents_full  – plain DataFrame with speed_t0/t+1 + accel_t0/t+1 columns
+    * cents_speed – plain DataFrame with speed_t0/t+1 columns only
+    """
+
+    @pytest.fixture()
+    def ctx(self):
+        t = _make_tracking("r", n_frames=80, seed=9)
+        feat_full = _make_features_with(t, ["speed", "accel"], seed=9)
+        feat_no_accel = _make_features_with(t, ["speed"], seed=9)
+
+        emb_full = {"speed": [0, 1], "accel": [0, 1]}
+        emb_speed = {"speed": [0, 1]}
+
+        cols_full = feat_full.embedding_df(emb_full).columns.tolist()
+        cols_speed = feat_full.embedding_df(emb_speed).columns.tolist()
+
+        cents_full = _plain_cents(cols_full)
+        cents_speed = _plain_cents(cols_speed)
+
+        return {
+            "t": t,
+            "feat_full": feat_full,
+            "feat_no_accel": feat_no_accel,
+            "emb_full": emb_full,
+            "emb_speed": emb_speed,
+            "cols_full": cols_full,
+            "cols_speed": cols_speed,
+            "cents_full": cents_full,
+            "cents_speed": cents_speed,
+        }
+
+    # --- "self" mode --------------------------------------------------------
+
+    def test_self_mode_warns_missing_base_and_assigns(self, ctx):
+        """
+        allow_missing_features='self': self is missing 'accel'.
+
+        Expected warnings
+        -----------------
+        1. Pre-filter: 'accel' base feature absent from self → embedding trimmed.
+        2. Reconciliation (only_in_centroids): accel_t0 / accel_t+1 present in
+           centroids but not in the reduced embed_df → dropped from centroids.
+
+        Assignment must succeed in the speed-only subspace.
+        """
+        c = ctx
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = c["feat_no_accel"].assign_clusters_by_centroids(
+                c["cents_full"],
+                c["emb_full"],
+                allow_missing_features="self",
+            )
+
+        messages = [str(w.message) for w in caught if issubclass(w.category, UserWarning)]
+        # Warning 1: missing base feature
+        assert any("absent from self" in m and "accel" in m for m in messages), messages
+        # Warning 2: centroid columns dropped
+        assert any("centroid column(s)" in m and "accel" in m for m in messages), messages
+
+        labels = pd.Series(result)
+        assert len(labels) == len(c["feat_no_accel"].data)
+        assert labels.notna().any()
+        assert set(labels.dropna().unique()).issubset({0, 1})
+
+    def test_self_mode_meta_records_flag(self, ctx):
+        """allow_missing_features is stored in _params."""
+        c = ctx
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = c["feat_no_accel"].assign_clusters_by_centroids(
+                c["cents_full"],
+                c["emb_full"],
+                allow_missing_features="self",
+            )
+        assert result._params["allow_missing_features"] == "self"
+
+    def test_self_mode_raises_when_self_has_extra_cols_not_in_centroids(self, ctx):
+        """
+        allow_missing_features='self' only covers self having *fewer* features.
+        If self produces columns the centroids don't have, that is a 'centroids'
+        problem and must raise with a helpful suggestion.
+        """
+        c = ctx
+        # feat_full has both speed + accel; cents_speed only has speed → only_in_self non-empty
+        with pytest.raises(ValueError, match="allow_missing_features='centroids' or 'both'"):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                c["feat_full"].assign_clusters_by_centroids(
+                    c["cents_speed"],
+                    c["emb_full"],
+                    allow_missing_features="self",
+                )
+
+    # --- "centroids" mode ---------------------------------------------------
+
+    def test_centroids_mode_warns_extra_self_cols_and_assigns(self, ctx):
+        """
+        allow_missing_features='centroids': centroids fitted on speed only, self
+        has speed + accel.
+
+        Expected warning
+        ----------------
+        Reconciliation (only_in_self): accel_t0 / accel_t+1 produced by self
+        have no counterpart in the speed-only centroids → dropped.
+
+        Assignment must succeed in the speed-only subspace.
+        """
+        c = ctx
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = c["feat_full"].assign_clusters_by_centroids(
+                c["cents_speed"],
+                c["emb_full"],
+                allow_missing_features="centroids",
+            )
+
+        messages = [str(w.message) for w in caught if issubclass(w.category, UserWarning)]
+        assert any(
+            "embedding column(s) produced by self" in m and "accel" in m for m in messages
+        ), messages
+
+        labels = pd.Series(result)
+        assert len(labels) == len(c["feat_full"].data)
+        assert labels.notna().any()
+        assert set(labels.dropna().unique()).issubset({0, 1})
+
+    def test_centroids_mode_raises_when_self_missing_base(self, ctx):
+        """
+        allow_missing_features='centroids' does NOT tolerate self missing base
+        features — the pre-filter only applies to 'self' / 'both'.
+        """
+        c = ctx
+        # feat_no_accel missing 'accel'; embedding_df would raise internally
+        with pytest.raises(ValueError, match="not present in self.data"):
+            c["feat_no_accel"].assign_clusters_by_centroids(
+                c["cents_full"],
+                c["emb_full"],
+                allow_missing_features="centroids",
+            )
+
+    # --- "both" mode --------------------------------------------------------
+
+    def test_both_mode_warns_all_sides_and_assigns(self, ctx):
+        """
+        allow_missing_features='both': self missing 'extra_feat', centroids built
+        on speed + extra_feat, embedding also asks for accel (present in self but
+        not in centroids).
+
+        Expected warnings
+        -----------------
+        1. Pre-filter: 'extra_feat' absent from self.
+        2. Reconciliation (only_in_self): accel_t0/t+1 produced by self but not
+           in the extra_feat centroids → dropped.
+        3. Reconciliation (only_in_centroids): extra_feat_t0/t+1 in centroids
+           but not produced by self → dropped.
+
+        Assignment succeeds in the speed-only subspace.
+        """
+        c = ctx
+        # Build centroids that have speed + an 'extra_feat' column
+        extra_cols = ["extra_feat_t0", "extra_feat_t+1"]
+        cols_speed_extra = c["cols_speed"] + extra_cols
+        cents_speed_extra = _plain_cents(cols_speed_extra)
+
+        # Embedding that requests speed + accel (both in self) + extra_feat (absent)
+        emb_three = {"speed": [0, 1], "accel": [0, 1], "extra_feat": [0, 1]}
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = c["feat_full"].assign_clusters_by_centroids(
+                cents_speed_extra,
+                emb_three,
+                allow_missing_features="both",
+            )
+
+        messages = [str(w.message) for w in caught if issubclass(w.category, UserWarning)]
+        # Warning 1: 'extra_feat' missing from self (pre-filter)
+        assert any("absent from self" in m and "extra_feat" in m for m in messages), messages
+        # Warning 2: accel columns dropped from self side
+        assert any(
+            "embedding column(s) produced by self" in m and "accel" in m for m in messages
+        ), messages
+        # Warning 3: extra_feat columns dropped from centroid side
+        assert any("centroid column(s)" in m and "extra_feat" in m for m in messages), messages
+
+        labels = pd.Series(result)
+        assert len(labels) == len(c["feat_full"].data)
+        assert labels.notna().any()
+        assert set(labels.dropna().unique()).issubset({0, 1})
+
+    # --- no shared columns --------------------------------------------------
+
+    def test_empty_intersection_raises_for_self_and_both_modes(self, ctx):
+        """
+        "self" and "both" reach the intersection check; with no columns in common
+        a ValueError is raised.
+
+        Scenario: self only has 'speed'; embedding asks for 'accel' only;
+        centroids also have only 'accel' columns.  After the pre-filter strips
+        'accel' from the embedding (absent from self) the embed_df is empty,
+        so the shared subspace is empty.
+        """
+        c = ctx
+        cols_accel = [col for col in c["cols_full"] if col.startswith("accel")]
+        cents_accel_only = _plain_cents(cols_accel)
+        emb_accel = {"accel": [0, 1]}
+
+        for mode in ("self", "both"):
+            with pytest.raises(ValueError, match="No columns remain in common"):
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    c["feat_no_accel"].assign_clusters_by_centroids(
+                        cents_accel_only,
+                        emb_accel,
+                        allow_missing_features=mode,
+                    )
+
+    def test_centroids_mode_raises_from_embedding_df_when_self_missing_base(self, ctx):
+        """
+        "centroids" mode does not pre-filter the embedding, so if self is missing
+        a base feature embedding_df raises before the intersection check is reached.
+        """
+        c = ctx
+        cols_accel = [col for col in c["cols_full"] if col.startswith("accel")]
+        cents_accel_only = _plain_cents(cols_accel)
+        emb_accel = {"accel": [0, 1]}
+
+        with pytest.raises(ValueError, match="not present in self.data"):
+            c["feat_no_accel"].assign_clusters_by_centroids(
+                cents_accel_only,
+                emb_accel,
+                allow_missing_features="centroids",
+            )
+
+    # --- default (None) still strict ----------------------------------------
+
+    def test_default_none_still_raises_on_mismatch(self, ctx):
+        """Without allow_missing_features the strict column-equality check is preserved."""
+        c = ctx
+        with pytest.raises(ValueError, match="Columns in embedding and centroids do not match"):
+            c["feat_full"].assign_clusters_by_centroids(
+                c["cents_speed"],
+                c["emb_full"],
+            )

--- a/tests/test_featurescollection_clustering.py
+++ b/tests/test_featurescollection_clustering.py
@@ -429,9 +429,21 @@ class TestAssignClusters:
 
     def test_new_scaling_factors_param(self, setup):
         feat, emb, cents, sf = setup
-        result = feat.assign_clusters_by_centroids(emb, cents, scaling_factors=sf)
+        result = feat.assign_clusters_by_centroids(cents, emb, scaling_factors=sf)
         assert len(result) == len(feat.data)
         assert pd.Series(result).notna().sum() > 0
+
+    def test_centroidsdf_no_embedding_needed(self, setup):
+        feat, emb, cents, _ = setup
+        # CentroidsDf carries embedding in recipe — no need to pass it
+        result = feat.assign_clusters_by_centroids(cents)
+        assert len(result) == len(feat.data)
+        assert pd.Series(result).notna().sum() > 0
+
+    def test_plain_df_requires_embedding(self, setup):
+        feat, emb, cents, _ = setup
+        with pytest.raises(ValueError, match="embedding is required"):
+            feat.assign_clusters_by_centroids(cents.to_df())
 
     def test_removed_rescale_factors_raises(self, setup):
         feat, emb, cents, sf = setup
@@ -439,14 +451,14 @@ class TestAssignClusters:
         embed_cols = feat.embedding_df(emb).columns
         rf = {c: 1.0 for c in embed_cols}
         with pytest.raises(NotImplementedError, match="rescale_factors"):
-            feat.assign_clusters_by_centroids(emb, cents, rescale_factors=rf)
+            feat.assign_clusters_by_centroids(cents, emb, rescale_factors=rf)
 
     def test_removed_custom_scaling_raises(self, setup):
         feat, emb, cents, _ = setup
         with pytest.raises(NotImplementedError, match="custom_scaling"):
             feat.assign_clusters_by_centroids(
-                emb,
                 cents,
+                emb,
                 custom_scaling={"speed": {"scale": 1.0}, "accel": {"scale": 1.0}},
             )
 
@@ -635,10 +647,10 @@ class TestCentroidsDf:
         """Recipe-based assign on the same data should match scaling_factors assign."""
         fc, emb, _, centroids, sf = setup
         feat = fc[list(fc.keys())[0]]
-        # Via recipe (CentroidsDf)
-        result_recipe = feat.assign_clusters_by_centroids(emb, centroids)
-        # Via legacy scaling_factors (plain DF)
-        result_sf = feat.assign_clusters_by_centroids(emb, centroids.to_df(), scaling_factors=sf)
+        # Via recipe (CentroidsDf) — embedding inferred from recipe
+        result_recipe = feat.assign_clusters_by_centroids(centroids)
+        # Via legacy scaling_factors (plain DF) — embedding must be provided
+        result_sf = feat.assign_clusters_by_centroids(centroids.to_df(), emb, scaling_factors=sf)
         pd.testing.assert_series_equal(
             pd.Series(result_recipe).astype("Int64"),
             pd.Series(result_sf).astype("Int64"),
@@ -772,7 +784,7 @@ class TestNormalizeDetails:
             normalize_details={"speed": "individual", "accel": "global"},
         )
         feat = fc[list(fc.keys())[0]]
-        result = feat.assign_clusters_by_centroids(emb, centroids)
+        result = feat.assign_clusters_by_centroids(centroids)
         labels = pd.Series(result)
         assert len(labels) == len(feat.data)
         assert labels.notna().any()


### PR DESCRIPTION
### Summary
<!-- 
A short description of what this PR does.

Example:
- Adds aggregation functions for multi-animal keypoint trajectories.
-->

- `normalize_details` parameter added to `cluster_embedding_stream`, allowing per-column normalisation modes (`"global"`, `"individual"`, `"none"`) via substring matching.
- new `CentroidsDf` class that is a thin emulator of Pandas df, now stores a complete `scaling_recipe` (embedding, normalisation modes, constant factors, imputation means), so `assign_clusters_by_centroids` can reproduce the full training transform on new data automatically.
- consequently, `cluster_embedding_stream` now only returns (`BatchResult`, `CentroidsDf`)
- `cluster_embedding` removed; `cluster_embedding_stream` is now the only clustering path. Raises `NotImplementedError` pointing to py3r.behaviour ≤ 3.2.1 for exact legacy results.
- huge simplification of `clustering_pipeline.py`, including `ClusteringPipeline` class being dissolved into `fit_cluster_embedding()`
- `Features.assign_clusters_by_centroids` also tolerates mismatches between observed and clustered features with user control.

### Type of change
<!-- 
At least one MUST be checked.
Use lowercase x exactly like this: [x]
-->
- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [x] 💥 Breaking change
- [x] 🧹 Chore / Refactor
- [ ] 📚 Docs

### User-facing change
<!-- 
This is what will appear in the release notes.
Write as a single bullet starting with - 

Example:
- Fixed incorrect body-angle computation when animals rotate >180°.
-->
- `normalize_details` parameter added to `cluster_embedding_stream`, allowing per-column normalisation modes (`"global"`, `"individual"`, `"none"`) via substring matching.
- `assign_clusters_by_centroids` can now reproduce the full training transform on new data automatically via the returns of  `cluster_embedding_stream`: (`BatchResult`, `CentroidsDf`)
- `cluster_embedding` removed; `cluster_embedding_stream` is now the only clustering path. Raises `NotImplementedError` pointing to py3r.behaviour ≤ 3.2.1 for exact legacy results.

### Testing
<!-- 
Explain how you tested the change.

Example:
- Added docstring tests covering interpolation of missing keypoints.
-->
- bespoke, unit, integration
