### PR TITLE
v1.0 axis feature

### DIFF
--- a/src/py3r/behaviour/animation/_projection.py
+++ b/src/py3r/behaviour/animation/_projection.py
@@ -10,21 +10,23 @@ def _is_valid(pix: np.ndarray, idx: int) -> bool:
 def _compute_bounds(
     points_xy: np.ndarray,
     boundary_arrays: list[tuple[str, np.ndarray]],
+    axis_arrays: list[tuple[str, np.ndarray]] | None = None,
     pad: float = 0.05,
 ) -> tuple[float, float, float, float]:
     flat = points_xy.reshape(-1, 2)
     valid = np.isfinite(flat[:, 0]) & np.isfinite(flat[:, 1])
     xs = [flat[valid, 0]] if np.any(valid) else []
     ys = [flat[valid, 1]] if np.any(valid) else []
-    for _, arr in boundary_arrays:
-        poly = np.asarray(arr, dtype=float)
-        if poly.ndim != 3 or poly.shape[2] != 2 or poly.shape[0] == 0 or poly.shape[1] == 0:
+    all_arrays = list(boundary_arrays) + list(axis_arrays or [])
+    for _, arr in all_arrays:
+        a = np.asarray(arr, dtype=float)
+        if a.ndim != 3 or a.shape[2] != 2 or a.shape[0] == 0 or a.shape[1] == 0:
             continue
-        flat_poly = poly.reshape(-1, 2)
-        ok = np.isfinite(flat_poly[:, 0]) & np.isfinite(flat_poly[:, 1])
+        flat_a = a.reshape(-1, 2)
+        ok = np.isfinite(flat_a[:, 0]) & np.isfinite(flat_a[:, 1])
         if np.any(ok):
-            xs.append(flat_poly[ok, 0])
-            ys.append(flat_poly[ok, 1])
+            xs.append(flat_a[ok, 0])
+            ys.append(flat_a[ok, 1])
     if not xs:
         return 0.0, 1.0, 0.0, 1.0
     xmin, xmax = float(np.min(np.concatenate(xs))), float(np.max(np.concatenate(xs)))
@@ -165,3 +167,91 @@ def _project_boundary_arrays_3d_to_2d(
             raise ValueError("Boundary array must have 2 or 3 dimensions on last axis")
         projected.append((str(name), _project_xyz_with_projector(xyz, projector)))
     return projected
+
+
+def _data_to_pixel_float(
+    data_xy: np.ndarray,
+    width: int,
+    height: int,
+    bounds: tuple[float, float, float, float],
+    pixel_coords: bool,
+) -> np.ndarray:
+    """Convert data-space coordinates to float pixel coordinates.
+
+    Unlike ``_coords_to_pixels``, this function does *not* clip to canvas
+    bounds or substitute a sentinel for out-of-bounds values.  It is intended
+    for computing axis line intersections with the canvas edge.
+
+    Parameters
+    ----------
+    data_xy : np.ndarray
+        Shape ``(n, 2)`` data coordinates.
+    width, height : int
+        Canvas dimensions in pixels.
+    bounds : tuple[float, float, float, float]
+        ``(xmin, xmax, ymin, ymax)`` data-space bounds.
+    pixel_coords : bool
+        If True, ``data_xy`` is already in pixel space and is returned
+        unchanged (rounded to float).
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``(n, 2)`` float pixel coordinates.
+    """
+    arr = np.asarray(data_xy, dtype=float)
+    if pixel_coords:
+        return arr.copy()
+    xmin, xmax, ymin, ymax = bounds
+    sx = max(width - 1, 1) / (xmax - xmin)
+    sy = max(height - 1, 1) / (ymax - ymin)
+    px = (arr[:, 0] - xmin) * sx
+    py = (height - 1) - ((arr[:, 1] - ymin) * sy)
+    return np.stack([px, py], axis=1)
+
+
+def _clip_axis_to_canvas(
+    p1: np.ndarray,
+    p2: np.ndarray,
+    width: int,
+    height: int,
+) -> tuple[np.ndarray, np.ndarray] | None:
+    """Find the two canvas-edge intersection points of an infinite axis.
+
+    The axis is defined by two float pixel-space reference points ``p1`` and
+    ``p2`` (which may lie outside the canvas).
+
+    Returns ``None`` if the axis does not intersect the canvas, or if the two
+    reference points are coincident.
+    """
+    p1 = np.asarray(p1, dtype=float)
+    p2 = np.asarray(p2, dtype=float)
+    d = p2 - p1  # direction vector
+
+    ts: list[float] = []
+    eps = 1e-9
+
+    if abs(d[0]) > eps:
+        for x_edge in (0.0, float(width - 1)):
+            t = (x_edge - p1[0]) / d[0]
+            y = p1[1] + t * d[1]
+            if -0.5 <= y <= height - 0.5:
+                ts.append(t)
+
+    if abs(d[1]) > eps:
+        for y_edge in (0.0, float(height - 1)):
+            t = (y_edge - p1[1]) / d[1]
+            x = p1[0] + t * d[0]
+            if -0.5 <= x <= width - 0.5:
+                ts.append(t)
+
+    if len(ts) < 2:
+        return None
+
+    t_min, t_max = min(ts), max(ts)
+    if abs(t_max - t_min) < eps:
+        return None
+
+    cp1 = np.round(p1 + t_min * d).astype(np.int32)
+    cp2 = np.round(p1 + t_max * d).astype(np.int32)
+    return cp1, cp2

--- a/src/py3r/behaviour/animation/_style.py
+++ b/src/py3r/behaviour/animation/_style.py
@@ -118,6 +118,24 @@ def _style_for_boundary(style: dict, boundary_name: str) -> dict:
     return merged
 
 
+def _style_raw_for_axis(style: dict, name: str) -> dict:
+    section = style.get("axes", {})
+    merged = {"edge_color": (0, 255, 0), "edge_width": 1}
+    merged.update(section.get("default", {}))
+    merged.update(section.get(name, {}))
+    return merged
+
+
+def _style_for_axis(style: dict, name: str) -> dict:
+    merged = _style_raw_for_axis(style, name)
+    _replace_dynamic_specs(merged, {"edge_color": (0, 255, 0), "edge_width": 1})
+    merged["edge_color"] = (
+        None if merged["edge_color"] is None else tuple(map(int, merged["edge_color"]))
+    )
+    merged["edge_width"] = int(merged["edge_width"])
+    return merged
+
+
 def _style_raw_for_text(style: dict, label: str) -> dict:
     section = style.get("text", {})
     merged = {

--- a/src/py3r/behaviour/animation/animation_stream.py
+++ b/src/py3r/behaviour/animation/animation_stream.py
@@ -4,8 +4,10 @@ import cv2
 import numpy as np
 
 from ._projection import (
+    _clip_axis_to_canvas,
     _compute_bounds,
     _coords_to_pixels,
+    _data_to_pixel_float,
     _is_valid,
     _make_projector,
     _project_boundary_arrays_3d_to_2d,
@@ -17,10 +19,12 @@ from ._style import (
     _format_overlay_value,
     _is_dynamic_spec,
     _resolve_text_color_for_frame,
+    _style_for_axis,
     _style_for_boundary,
     _style_for_line,
     _style_for_point,
     _style_for_text,
+    _style_raw_for_axis,
     _style_raw_for_boundary,
     _style_raw_for_line,
     _style_raw_for_point,
@@ -50,6 +54,7 @@ class AnimationStream:
         lines_idx: list[tuple[int, int]],
         line_keys: list[tuple[str, str]],
         boundary_arrays: list[tuple[str, np.ndarray]],
+        axis_arrays: list[tuple[str, np.ndarray]] | None = None,
         text_overlays: list[tuple[str, np.ndarray | None]] | None,
         canvas_size: tuple[int, int],
         fps: float,
@@ -67,6 +72,11 @@ class AnimationStream:
             barr = np.asarray(arr)
             if barr.ndim != 3 or barr.shape[0] != points_xy.shape[0] or barr.shape[2] != 2:
                 raise ValueError("Boundary arrays must have shape (n_frames, n_vertices, 2)")
+        for _, arr in axis_arrays or []:
+            aarr = np.asarray(arr)
+            n = points_xy.shape[0]
+            if aarr.ndim != 3 or aarr.shape[0] != n or aarr.shape[1] != 2 or aarr.shape[2] != 2:
+                raise ValueError("Axis arrays must have shape (n_frames, 2, 2)")
         if text_overlays is None:
             text_overlays = []
         for label, values in text_overlays:
@@ -85,6 +95,9 @@ class AnimationStream:
         self._boundary_arrays = [
             (str(name), np.asarray(arr, dtype=float)) for name, arr in boundary_arrays
         ]
+        self._axis_arrays = [
+            (str(name), np.asarray(arr, dtype=float)) for name, arr in (axis_arrays or [])
+        ]
         self._style = style or {}
         self._style_sources = style_sources or {}
         self._text_overlays = []
@@ -97,6 +110,7 @@ class AnimationStream:
             "points": {},
             "lines": {},
             "boundaries": {},
+            "axes": {},
             "text": {},
         }
         n_frames = points_xy.shape[0]
@@ -129,6 +143,8 @@ class AnimationStream:
         boundary_names = {name for name, _ in self._boundary_arrays}
         for b in boundary_names:
             _populate("boundaries", b, _style_raw_for_boundary(self._style, b))
+        for ax_name, _ in self._axis_arrays:
+            _populate("axes", ax_name, _style_raw_for_axis(self._style, ax_name))
         for label, values in self._text_overlays:
             if values is None:
                 continue
@@ -139,7 +155,9 @@ class AnimationStream:
         self._bg_color = tuple(map(int, bg_color))
         self._pixel_coords = bool(pixel_coords)
         self._cursor = 0
-        self._bounds = _compute_bounds(points_xy, self._boundary_arrays, pad=bounds_pad)
+        self._bounds = _compute_bounds(
+            points_xy, self._boundary_arrays, self._axis_arrays, pad=bounds_pad
+        )
 
     @property
     def frame_count(self) -> int:
@@ -337,6 +355,25 @@ class AnimationStream:
                     color=edge_color,
                     thickness=edge_width,
                 )
+
+        w, h = target.shape[1], target.shape[0]
+        for ax_name, ax_arr in self._axis_arrays:
+            seg = ax_arr[frame_idx]  # (2, 2)
+            if not np.all(np.isfinite(seg)):
+                continue
+            pix_float = _data_to_pixel_float(seg, w, h, self._bounds, self._pixel_coords)
+            clipped = _clip_axis_to_canvas(pix_float[0], pix_float[1], w, h)
+            if clipped is None:
+                continue
+            cp1, cp2 = clipped
+            axstyle = _style_for_axis(self._style, ax_name)
+            axstyle = _apply_dynamic_overrides(
+                axstyle, self._dynamic_styles["axes"].get(ax_name), frame_idx
+            )
+            edge_width = int(axstyle["edge_width"])
+            edge_color = axstyle["edge_color"]
+            if edge_width > 0 and edge_color is not None:
+                cv2.line(target, tuple(cp1), tuple(cp2), edge_color, edge_width)
 
         pts = self._points_xy[frame_idx]
         pix_pts = _coords_to_pixels(
@@ -659,6 +696,7 @@ def build_animation_stream(
     frame_ids: np.ndarray,
     fps: float = 30.0,
     boundary_arrays: list[tuple[str, np.ndarray]] | None = None,
+    axis_arrays: list[tuple[str, np.ndarray]] | None = None,
     canvas_size: tuple[int, int] = (800, 800),
     bg_color: tuple[int, int, int] = (0, 0, 0),
     style: dict | None = None,
@@ -725,6 +763,13 @@ def build_animation_stream(
         barr = np.asarray(arr)
         if barr.ndim != 3 or barr.shape[0] != points.shape[0] or barr.shape[2] not in (2, 3):
             raise ValueError("Boundary arrays must have shape (n_frames, n_vertices, 2|3)")
+    if axis_arrays is None:
+        axis_arrays = []
+    for _, arr in axis_arrays:
+        aarr = np.asarray(arr)
+        n = points.shape[0]
+        if aarr.ndim != 3 or aarr.shape[0] != n or aarr.shape[1] != 2 or aarr.shape[2] != 2:
+            raise ValueError("Axis arrays must have shape (n_frames, 2, 2)")
     if text_overlays is None:
         text_overlays = []
 
@@ -763,6 +808,7 @@ def build_animation_stream(
         lines_idx=lines_idx,
         line_keys=line_keys,
         boundary_arrays=boundary_arrays,
+        axis_arrays=axis_arrays,
         text_overlays=text_overlays,
         canvas_size=canvas_size,
         fps=fps,

--- a/src/py3r/behaviour/features/__init__.py
+++ b/src/py3r/behaviour/features/__init__.py
@@ -1,3 +1,4 @@
+from .axis import DynamicAxis, StaticAxis
 from .boundary import DynamicBoundary, StaticBoundary
 from .features import Features
 from .features_collection import FeaturesCollection
@@ -6,6 +7,8 @@ from .features_result import FeaturesResult
 __all__ = [
     "StaticBoundary",
     "DynamicBoundary",
+    "StaticAxis",
+    "DynamicAxis",
     "Features",
     "FeaturesResult",
     "FeaturesCollection",

--- a/src/py3r/behaviour/features/assets.py
+++ b/src/py3r/behaviour/features/assets.py
@@ -1,0 +1,28 @@
+"""Asset type registry for Features geometric assets.
+
+Geometric assets follow a static/dynamic pair pattern:
+- StaticX  — resolved numeric coordinates, fixed across frames.
+- DynamicX — keypoint name references, resolved per frame from tracking data.
+
+To add a new asset type, create its dataclass (with ``to_dict`` / ``from_dict`` /
+``with_name``), give it a unique ``"kind"`` string, and add one entry here.
+"""
+
+from __future__ import annotations
+
+from py3r.behaviour.features.axis import DynamicAxis, StaticAxis
+from py3r.behaviour.features.boundary import DynamicBoundary, StaticBoundary
+
+# Maps serialised "kind" strings to asset classes.
+_ASSET_KINDS: dict[str, type] = {
+    "static_boundary": StaticBoundary,
+    "dynamic_boundary": DynamicBoundary,
+    "static_axis": StaticAxis,
+    "dynamic_axis": DynamicAxis,
+}
+
+# Backward compatibility: files saved before the kind rename used "static" / "dynamic".
+_LEGACY_ASSET_KINDS: dict[str, type] = {
+    "static": StaticBoundary,
+    "dynamic": DynamicBoundary,
+}

--- a/src/py3r/behaviour/features/axis.py
+++ b/src/py3r/behaviour/features/axis.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+def _transform_axis_endpoints(
+    A: np.ndarray,
+    B: np.ndarray,
+    offset: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Shift static axis reference points perpendicularly by ``offset``.
+
+    Parameters
+    ----------
+    A, B : np.ndarray
+        Reference point coordinate vectors, shape ``(n_dims,)``.
+    offset : float
+        Perpendicular displacement in coordinate units.  Positive is to
+        the right when facing from A to B.  Must be ``0.0`` for axes with
+        more than 2 dimensions.
+    """
+    if offset == 0.0:
+        return A.copy(), B.copy()
+    n_dims = len(A)
+    if n_dims != 2:
+        raise ValueError(f"offset is only supported for 2-D axes; got {n_dims} dims.")
+    d = B - A
+    length = np.linalg.norm(d)
+    if length == 0:
+        raise ValueError("Cannot apply a non-zero offset to a zero-length axis (A == B).")
+    d_norm = d / length
+    perp = np.array([d_norm[1], -d_norm[0]])  # right-hand perpendicular
+    shift = offset * perp
+    return A + shift, B + shift
+
+
+def _transform_axis_per_frame(
+    arr: np.ndarray,
+    offset: float,
+) -> np.ndarray:
+    """Shift per-frame axis reference points perpendicularly by ``offset``.
+
+    Parameters
+    ----------
+    arr : np.ndarray
+        Shape ``(n_frames, 2, n_dims)`` — raw resolved axis reference points.
+    offset : float
+        Perpendicular displacement.  Must be ``0.0`` for ``n_dims != 2``.
+
+    Returns
+    -------
+    np.ndarray
+        Shifted array, same shape ``(n_frames, 2, n_dims)``.
+    """
+    if offset == 0.0:
+        return arr.copy()
+    n_dims = arr.shape[2]
+    if n_dims != 2:
+        raise ValueError(f"offset is only supported for 2-D axes; got {n_dims} dims.")
+    A = arr[:, 0, :]  # (n, 2)
+    B = arr[:, 1, :]  # (n, 2)
+    d = B - A  # (n, 2)
+    length = np.linalg.norm(d, axis=1, keepdims=True)  # (n, 1)
+    # Degenerate frames (A == B) get zero shift rather than NaN.
+    with np.errstate(invalid="ignore", divide="ignore"):
+        d_norm = np.where(length > 0, d / length, 0.0)  # (n, 2)
+    perp = np.stack([d_norm[:, 1], -d_norm[:, 0]], axis=1)  # (n, 2)
+    shift = offset * perp  # (n, 2)
+    return np.stack([A + shift, B + shift], axis=1)  # (n, 2, 2)
+
+
+@dataclass(frozen=True)
+class StaticAxis:
+    """A static infinite axis defined by two reference points in N-dimensional space.
+
+    The axis passes through both stored reference points and extends infinitely
+    in both directions.  Distance computations and rendering always treat it as
+    infinite: the reference points define *position* and *direction*, not
+    endpoints.
+
+    Unlike boundaries, ``dims`` may contain any number of coordinate names
+    (e.g. ``("x", "y")`` or ``("x", "y", "z")``).  The ``offset`` transform
+    is baked into the stored vertices at definition time.
+    """
+
+    vertices: tuple[tuple[float, ...], ...]  # exactly 2, each N-dim
+    dims: tuple[str, ...]
+    source_points: tuple[str, ...] | None = None
+    name: str | None = None
+
+    def with_name(self, name: str) -> StaticAxis:
+        return StaticAxis(
+            vertices=self.vertices,
+            dims=self.dims,
+            source_points=self.source_points,
+            name=name,
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "kind": "static_axis",
+            "vertices": [list(v) for v in self.vertices],
+            "dims": list(self.dims),
+            "source_points": list(self.source_points) if self.source_points is not None else None,
+            "name": self.name,
+        }
+
+    def to_numpy(self) -> np.ndarray:
+        """Return reference points as a float array of shape ``(2, n_dims)``."""
+        return np.array(self.vertices, dtype=float)
+
+    @classmethod
+    def from_dict(cls, payload: dict) -> StaticAxis:
+        vertices = tuple(tuple(float(c) for c in v) for v in payload["vertices"])
+        dims = tuple(str(d) for d in payload["dims"])
+        source_points = payload.get("source_points")
+        return cls(
+            vertices=vertices,
+            dims=dims,
+            source_points=tuple(source_points) if source_points is not None else None,
+            name=payload.get("name"),
+        )
+
+
+@dataclass(frozen=True)
+class DynamicAxis:
+    """A dynamic infinite axis defined by two keypoint names in N-dimensional space.
+
+    Reference-point coordinates are resolved per frame from tracking data at
+    compute time.  The axis is always treated as infinite in both distance
+    computations and rendering.
+
+    ``offset`` shifts the axis perpendicularly to its direction at each frame
+    (positive = right when facing from ``points[0]`` to ``points[1]``).
+    Only supported for 2-D axes.
+    """
+
+    points: tuple[str, str]
+    dims: tuple[str, ...]
+    offset: float = 0.0
+    name: str | None = None
+
+    def with_name(self, name: str) -> DynamicAxis:
+        return DynamicAxis(
+            points=self.points,
+            dims=self.dims,
+            offset=self.offset,
+            name=name,
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "kind": "dynamic_axis",
+            "points": list(self.points),
+            "dims": list(self.dims),
+            "offset": self.offset,
+            "name": self.name,
+        }
+
+    def to_numpy_per_frame(self, tracking_df) -> np.ndarray:
+        """Resolve axis point names against tracking data and apply offset.
+
+        Returns
+        -------
+        np.ndarray
+            Shape ``(n_frames, 2, n_dims)`` with offset applied.
+        """
+        cols_per_point = []
+        for point in self.points:
+            cols = [f"{point}.{dim}" for dim in self.dims]
+            missing = [c for c in cols if c not in tracking_df.columns]
+            if missing:
+                raise ValueError(
+                    f"Dynamic axis point {point!r} missing columns {missing} in tracking data."
+                )
+            cols_per_point.append(tracking_df[cols].to_numpy(dtype=float, copy=True))
+        arr = np.stack(cols_per_point, axis=1)  # (n_frames, 2, n_dims)
+
+        if self.offset != 0.0:
+            arr = _transform_axis_per_frame(arr, offset=self.offset)
+
+        return arr
+
+    @classmethod
+    def from_dict(cls, payload: dict) -> DynamicAxis:
+        points_raw = payload["points"]
+        if len(points_raw) != 2:
+            raise ValueError(f"DynamicAxis requires exactly 2 points; got {len(points_raw)}.")
+        dims = tuple(str(d) for d in payload["dims"])
+        return cls(
+            points=(str(points_raw[0]), str(points_raw[1])),
+            dims=dims,
+            offset=float(payload.get("offset", 0.0)),
+            name=payload.get("name"),
+        )

--- a/src/py3r/behaviour/features/boundary.py
+++ b/src/py3r/behaviour/features/boundary.py
@@ -35,7 +35,7 @@ class StaticBoundary:
 
     def to_dict(self) -> dict:
         return {
-            "kind": "static",
+            "kind": "static_boundary",
             "vertices": list(self.vertices),
             "dims": list(self.dims),
             "source_points": list(self.source_points) if self.source_points is not None else None,
@@ -89,7 +89,7 @@ class DynamicBoundary:
 
     def to_dict(self) -> dict:
         return {
-            "kind": "dynamic",
+            "kind": "dynamic_boundary",
             "points": list(self.points),
             "dims": list(self.dims),
             "anchor_points": list(self.anchor_points) if self.anchor_points is not None else None,

--- a/src/py3r/behaviour/features/features.py
+++ b/src/py3r/behaviour/features/features.py
@@ -13,6 +13,8 @@ import shapely
 from shapely.geometry import Polygon
 from sklearn.neighbors import KNeighborsRegressor
 
+from py3r.behaviour.features.assets import _ASSET_KINDS, _LEGACY_ASSET_KINDS
+from py3r.behaviour.features.axis import DynamicAxis, StaticAxis
 from py3r.behaviour.features.boundary import DynamicBoundary, StaticBoundary
 from py3r.behaviour.features.features_result import FeaturesResult
 from py3r.behaviour.tracking.tracking import Tracking
@@ -23,7 +25,7 @@ from py3r.behaviour.util.bmicro_utils import (
     train_knn_from_embeddings,
 )
 from py3r.behaviour.util.collection_utils import _Indexer
-from py3r.behaviour.util.dataframe_utils import coarse_grain_dataframe
+from py3r.behaviour.util.dataframe_utils import coarse_grain_dataframe, point_to_axis_distance
 from py3r.behaviour.util.dev_utils import dev_mode
 from py3r.behaviour.util.io_utils import (
     SchemaVersion,
@@ -672,46 +674,89 @@ class Features:
             "or Features.define_dynamic_boundary() instead."
         )
 
-    def _get_boundaries(self) -> dict[str, StaticBoundary | DynamicBoundary]:
-        boundaries = self._assets.get("boundaries")
-        if boundaries is None:
-            boundaries = {}
-            self._assets["boundaries"] = boundaries
-        return boundaries
+    # ------------------------------------------------------------------
+    # Generic asset registry (flat dict keyed by name)
+    # ------------------------------------------------------------------
 
     def _serialize_assets(self) -> dict:
-        boundaries = self._assets.get("boundaries", {})
-        payload = {"boundaries": {name: b.to_dict() for name, b in boundaries.items()}}
-        # keep room for future assets
-        return payload
+        return {name: asset.to_dict() for name, asset in self._assets.items()}
 
     def _deserialize_assets(self, payload: dict | None) -> dict[str, Any]:
         payload = payload or {}
-        boundaries_payload = payload.get("boundaries", {})
-        boundaries: dict[str, StaticBoundary | DynamicBoundary] = {}
-        for name, b in boundaries_payload.items():
-            kind = b.get("kind")
-            if kind == "static":
-                boundaries[name] = StaticBoundary.from_dict(b)
-            elif kind == "dynamic":
-                boundaries[name] = DynamicBoundary.from_dict(b)
-            else:
-                raise ValueError(f"Unknown boundary kind '{kind}' in saved assets.")
-        return {"boundaries": boundaries}
+        result: dict[str, Any] = {}
 
-    def _register_boundary(
-        self, boundary: StaticBoundary | DynamicBoundary, *, name: str | None, overwrite: bool
-    ) -> StaticBoundary | DynamicBoundary:
+        # Backward compatibility: files saved before the asset refactor stored
+        # boundaries under a nested "boundaries" key with kinds "static"/"dynamic".
+        for name, data in payload.get("boundaries", {}).items():
+            kind = data.get("kind")
+            cls = _ASSET_KINDS.get(kind) or _LEGACY_ASSET_KINDS.get(kind)
+            if cls is None:
+                raise ValueError(f"Unknown asset kind {kind!r} in saved assets.")
+            result[name] = cls.from_dict(data)
+
+        # Current flat format: each top-level key is an asset name.
+        for name, data in payload.items():
+            if name == "boundaries":
+                continue
+            kind = data.get("kind")
+            cls = _ASSET_KINDS.get(kind)
+            if cls is None:
+                raise ValueError(f"Unknown asset kind {kind!r} in saved assets.")
+            result[name] = cls.from_dict(data)
+
+        return result
+
+    def _register_asset(self, asset, *, name: str | None, overwrite: bool):
         if name is None:
-            return boundary
-        boundaries = self._get_boundaries()
-        if name in boundaries and not overwrite:
+            return asset
+        if name in self._assets and not overwrite:
             raise ValueError(
-                f"Boundary with name '{name}' already exists. Set overwrite=True to replace it."
+                f"Asset with name {name!r} already exists. Set overwrite=True to replace it."
             )
-        named = boundary.with_name(name)
-        boundaries[name] = named
+        named = asset.with_name(name)
+        self._assets[name] = named
         return named
+
+    def get_asset(self, name: str):
+        """Return a named geometric asset (boundary or line) by name.
+
+        Raises
+        ------
+        KeyError
+            If no asset with ``name`` is registered.
+        """
+        try:
+            return self._assets[name]
+        except KeyError:
+            available = list(self._assets)
+            raise KeyError(f"No asset {name!r} registered. Available: {available}") from None
+
+    def list_assets(self) -> pd.DataFrame:
+        """Return a table of all named geometric assets on this Features object.
+
+        Returns
+        -------
+        pd.DataFrame
+            Indexed by asset name, columns: ``asset_type``, ``dims``, ``n_points``.
+        """
+        rows = []
+        for name, asset in self._assets.items():
+            n = (
+                len(asset.vertices)
+                if isinstance(asset, (StaticBoundary, StaticAxis))
+                else len(asset.points)
+            )
+            rows.append(
+                {
+                    "name": name,
+                    "asset_type": type(asset).__name__,
+                    "dims": asset.dims,
+                    "n_points": n,
+                }
+            )
+        if not rows:
+            return pd.DataFrame(columns=["asset_type", "dims", "n_points"])
+        return pd.DataFrame(rows).set_index("name")
 
     def _resolve_anchor(self, points: list[str], dims: tuple[str, str], anchor):
         if anchor is None:
@@ -775,7 +820,7 @@ class Features:
             scale_dim2=float(scale_dim2),
             name=name,
         )
-        return self._register_boundary(boundary, name=name, overwrite=overwrite)
+        return self._register_asset(boundary, name=name, overwrite=overwrite)
 
     def define_dynamic_boundary(
         self,
@@ -803,7 +848,7 @@ class Features:
             scale_dim2=float(scale_dim2),
             name=name,
         )
-        return self._register_boundary(boundary, name=name, overwrite=overwrite)
+        return self._register_asset(boundary, name=name, overwrite=overwrite)
 
     def import_static_boundary(
         self,
@@ -820,48 +865,188 @@ class Features:
             raise ValueError("Imported static boundary requires at least 3 vertices.")
         verts = tuple((float(x), float(y)) for x, y in vertices)
         boundary = StaticBoundary(vertices=verts, dims=(dims[0], dims[1]), name=name)
-        return self._register_boundary(boundary, name=name, overwrite=overwrite)
+        return self._register_asset(boundary, name=name, overwrite=overwrite)
+
+    # ------------------------------------------------------------------
+    # Axis asset factories
+    # ------------------------------------------------------------------
+
+    def define_static_axis(
+        self,
+        point1: str,
+        point2: str,
+        *,
+        dims: tuple[str, ...] = ("x", "y"),
+        offset: float = 0.0,
+        name: str | None = None,
+        overwrite: bool = False,
+    ) -> StaticAxis:
+        """Define a static axis from the medians of two keypoints.
+
+        The axis is fixed in space: median coordinates are computed once from
+        the full tracking session.  The offset is baked into the stored
+        reference points at definition time.  The axis is always treated as
+        infinite (no endpoints) in both distance computations and rendering.
+
+        Parameters
+        ----------
+        point1 : str
+            First keypoint defining the axis direction.
+        point2 : str
+            Second keypoint defining the axis direction.
+        dims : tuple[str, ...], default ``("x", "y")``
+            Coordinate dimensions.  Any number of dims is supported
+            (e.g. ``("x", "y", "z")`` for 3-D axis distance).
+        offset : float, default 0.0
+            Shift both reference points perpendicularly by this amount.
+            Positive is to the right when facing from ``point1`` to
+            ``point2``.  Only supported for 2-D axes.
+        name : str or None
+            If given, register the axis under this name.
+        overwrite : bool, default False
+            Allow replacing an existing asset with the same name.
+        """
+        from py3r.behaviour.features.axis import _transform_axis_endpoints
+
+        medians = [self.get_point_median(p, dims=dims) for p in (point1, point2)]
+        A = np.array(medians[0], dtype=float)
+        B = np.array(medians[1], dtype=float)
+        A_t, B_t = _transform_axis_endpoints(A, B, offset=offset)
+        axis = StaticAxis(
+            vertices=(tuple(float(c) for c in A_t), tuple(float(c) for c in B_t)),
+            dims=tuple(dims),
+            source_points=(point1, point2),
+            name=name,
+        )
+        return self._register_asset(axis, name=name, overwrite=overwrite)
+
+    def define_dynamic_axis(
+        self,
+        point1: str,
+        point2: str,
+        *,
+        dims: tuple[str, ...] = ("x", "y"),
+        offset: float = 0.0,
+        name: str | None = None,
+        overwrite: bool = False,
+    ) -> DynamicAxis:
+        """Define a dynamic axis from two keypoint names.
+
+        Reference-point coordinates are resolved per frame at compute time,
+        with offset applied during each resolution.  The axis is always treated
+        as infinite in both distance computations and rendering.
+
+        Parameters
+        ----------
+        point1 : str
+            First keypoint defining the axis direction.
+        point2 : str
+            Second keypoint defining the axis direction.
+        dims : tuple[str, ...], default ``("x", "y")``
+            Coordinate dimensions.
+        offset : float, default 0.0
+            Per-frame perpendicular displacement.  Positive is to the right
+            when facing from ``point1`` to ``point2``.  Only supported for
+            2-D axes.
+        name : str or None
+            If given, register the axis under this name.
+        overwrite : bool, default False
+            Allow replacing an existing asset with the same name.
+        """
+        self.tracking._assert_valid_point(point1)
+        self.tracking._assert_valid_point(point2)
+        axis = DynamicAxis(
+            points=(point1, point2),
+            dims=tuple(dims),
+            offset=offset,
+            name=name,
+        )
+        return self._register_asset(axis, name=name, overwrite=overwrite)
+
+    def import_static_axis(
+        self,
+        vertices: list[tuple[float, ...]],
+        *,
+        dims: tuple[str, ...] = ("x", "y"),
+        name: str | None = None,
+        overwrite: bool = False,
+    ) -> StaticAxis:
+        """Import a static axis from explicit reference-point coordinates.
+
+        Parameters
+        ----------
+        vertices : list of tuple
+            Exactly two coordinate tuples in ``dims`` space.
+        dims : tuple[str, ...], default ``("x", "y")``
+            Coordinate dimensions.
+        name : str or None
+            If given, register the axis under this name.
+        overwrite : bool, default False
+            Allow replacing an existing asset with the same name.
+        """
+        if len(vertices) != 2:
+            raise ValueError(f"An axis requires exactly 2 reference points; got {len(vertices)}.")
+        verts = tuple(tuple(float(c) for c in v) for v in vertices)
+        axis = StaticAxis(vertices=verts, dims=tuple(dims), name=name)
+        return self._register_asset(axis, name=name, overwrite=overwrite)
 
     def get_boundary(self, name: str) -> StaticBoundary | DynamicBoundary:
-        """Draft accessor for named boundary assets."""
-        return self._get_boundaries()[name]
+        """Return a named boundary asset.
+
+        Raises ``KeyError`` if the name is not registered, ``TypeError`` if the
+        registered asset is not a boundary.
+        """
+        asset = self.get_asset(name)
+        if not isinstance(asset, (StaticBoundary, DynamicBoundary)):
+            raise TypeError(
+                f"Asset {name!r} is a {type(asset).__name__}, not a boundary. "
+                "Use get_asset() to retrieve non-boundary assets."
+            )
+        return asset
 
     def list_boundaries(self) -> pd.DataFrame:
-        """Return a compact table of named boundaries on this Features object."""
+        """Return a compact table of named boundary assets on this Features object."""
         rows = []
-        for name, boundary in self._get_boundaries().items():
-            if isinstance(boundary, StaticBoundary):
-                points_n = len(boundary.vertices)
-                kind = "static"
-                has_vertices = True
-            elif isinstance(boundary, DynamicBoundary):
-                points_n = len(boundary.points)
-                kind = "dynamic"
-                has_vertices = False
-            else:
-                raise TypeError(f"Unsupported boundary type in assets: {type(boundary).__name__}")
-            rows.append(
-                {
-                    "name": name,
-                    "kind": kind,
-                    "n_points": points_n,
-                    "has_vertices": has_vertices,
-                }
-            )
+        for name, asset in self._assets.items():
+            if isinstance(asset, StaticBoundary):
+                rows.append(
+                    {
+                        "name": name,
+                        "kind": "static",
+                        "n_points": len(asset.vertices),
+                        "has_vertices": True,
+                    }
+                )
+            elif isinstance(asset, DynamicBoundary):
+                rows.append(
+                    {
+                        "name": name,
+                        "kind": "dynamic",
+                        "n_points": len(asset.points),
+                        "has_vertices": False,
+                    }
+                )
         if not rows:
             return pd.DataFrame(columns=["kind", "n_points", "has_vertices"])
         return pd.DataFrame(rows).set_index("name")
 
     def _resolve_boundary_ref(self, boundary) -> StaticBoundary | DynamicBoundary:
-        resolved = self.get_boundary(boundary) if isinstance(boundary, str) else boundary
-        if isinstance(resolved, StaticBoundary):
-            return resolved
-        if isinstance(resolved, DynamicBoundary):
-            return resolved
-        raise TypeError(
-            "boundary must be a boundary name, StaticBoundary, or DynamicBoundary. "
-            f"Got {type(resolved).__name__}."
-        )
+        resolved = self.get_asset(boundary) if isinstance(boundary, str) else boundary
+        if not isinstance(resolved, (StaticBoundary, DynamicBoundary)):
+            raise TypeError(
+                "boundary must be a boundary name, StaticBoundary, or DynamicBoundary. "
+                f"Got {type(resolved).__name__}."
+            )
+        return resolved
+
+    def _resolve_axis_ref(self, axis) -> StaticAxis | DynamicAxis:
+        resolved = self.get_asset(axis) if isinstance(axis, str) else axis
+        if not isinstance(resolved, (StaticAxis, DynamicAxis)):
+            raise TypeError(
+                "axis must be an axis name, StaticAxis, or DynamicAxis. "
+                f"Got {type(resolved).__name__}."
+            )
+        return resolved
 
     @staticmethod
     def _is_legacy_point_name_list(boundary) -> bool:
@@ -1009,6 +1194,11 @@ class Features:
 
         ```
         """
+        if isinstance(boundary, (StaticAxis, DynamicAxis)):
+            raise TypeError(
+                "within_boundary does not accept axis assets. "
+                "Use distance_to_axis() for axis-based features."
+            )
         if isinstance(boundary, StaticBoundary):
             return self._within_boundary_static_impl(
                 point,
@@ -1068,6 +1258,11 @@ class Features:
 
         ```
         """
+        if isinstance(boundary, (StaticAxis, DynamicAxis)):
+            raise TypeError(
+                "distance_to_boundary does not accept axis assets. "
+                "Use distance_to_axis() for axis-based features."
+            )
         if isinstance(boundary, StaticBoundary):
             return self._distance_to_boundary_static_impl(
                 point,
@@ -1201,6 +1396,103 @@ class Features:
             "Features.distance_to_boundary(point, boundary) with a DynamicBoundary "
             "or stored boundary name instead."
         )
+
+    def distance_to_axis(
+        self,
+        point: str,
+        axis: str | StaticAxis | DynamicAxis,
+        *,
+        signed: bool = False,
+    ) -> FeaturesResult:
+        """Framewise perpendicular distance from a keypoint to an infinite axis.
+
+        The axis is always treated as extending infinitely in both directions.
+        Use :meth:`define_static_axis`, :meth:`define_dynamic_axis`, or
+        :meth:`import_static_axis` to create axis assets.
+
+        Parameters
+        ----------
+        point : str
+            Keypoint to measure from.
+        axis : str, StaticAxis, or DynamicAxis
+            A two-point axis asset, or the name of a registered one.
+        signed : bool, default False
+            If True, return a signed distance (2-D axes only).  Positive means
+            the point is to the *right* when facing from the first to the
+            second axis reference point; negative means it is to the *left*.
+            The sign convention matches :meth:`define_static_axis` ``offset``:
+            an ``offset > 0`` shifts the axis rightward, so a point that was
+            on the axis will have a negative signed distance from the
+            offset-shifted one.  Raises ``ValueError`` for non-2-D axes.
+
+        Returns
+        -------
+        FeaturesResult
+
+        Examples
+        --------
+        ```pycon
+        >>> from py3r.behaviour.util.docdata import data_path
+        >>> from py3r.behaviour.tracking.tracking import Tracking
+        >>> from py3r.behaviour.features.features import Features
+        >>> import pandas as pd
+        >>> with data_path('py3r.behaviour.tracking._data', 'dlc_single.csv') as p:
+        ...     t = Tracking.from_dlc(str(p), handle='ex', fps=30)
+        >>> f = Features(t)
+        >>> ax = f.define_dynamic_axis('p1', 'p2')
+        >>> res = f.distance_to_axis('p3', ax)
+        >>> isinstance(res, pd.Series) and len(res) == len(t.data)
+        True
+        >>> res_signed = f.distance_to_axis('p3', ax, signed=True)
+        >>> isinstance(res_signed, pd.Series) and len(res_signed) == len(t.data)
+        True
+
+        ```
+        """
+        resolved = self._resolve_axis_ref(axis)
+        dims = resolved.dims
+
+        if signed and len(dims) != 2:
+            raise ValueError(
+                f"signed=True requires a 2-D axis; axis {resolved.name!r} has dims {dims}."
+            )
+
+        if "rescale_distance_method" not in self.tracking.meta:
+            warnings.warn("distance has not been calibrated", stacklevel=2)
+        if "smoothing" not in self.tracking.meta:
+            warnings.warn("tracking data have not been smoothed", stacklevel=2)
+
+        df = self.tracking.data
+        n = len(df)
+        P = self.tracking.get_point_data(point, dims=list(dims)).to_numpy(dtype=float)
+
+        if isinstance(resolved, StaticAxis):
+            A = np.tile(np.array(resolved.vertices[0], dtype=float), (n, 1))
+            B = np.tile(np.array(resolved.vertices[1], dtype=float), (n, 1))
+        else:
+            arr = resolved.to_numpy_per_frame(df)  # (n, 2, d)
+            A = arr[:, 0, :]
+            B = arr[:, 1, :]
+
+        dist = point_to_axis_distance(P, A, B, signed=signed)
+        series = pd.Series(dist, index=df.index)
+
+        if resolved.name:
+            axis_label = resolved.name
+        elif isinstance(resolved, StaticAxis) and resolved.source_points:
+            axis_label = "_".join(resolved.source_points)
+        else:
+            axis_label = "_".join(resolved.points)
+
+        sign_suffix = "_signed" if signed else ""
+        name_str = f"distance_to_axis_{point}_from_{axis_label}_in_{''.join(dims)}{sign_suffix}"
+        meta = {
+            "function": "distance_to_axis",
+            "point": point,
+            "axis": resolved.to_dict(),
+            "signed": signed,
+        }
+        return FeaturesResult(series, self, name_str, meta)
 
     def area_of_boundary(
         self, boundary: str | StaticBoundary | DynamicBoundary, **kwargs
@@ -2541,6 +2833,7 @@ class Features:
         points: list[str],
         lines: list[tuple[str, str]] | None = None,
         boundaries: list[str] | None = None,
+        axes: list[str] | None = None,
         features: list[str | None] | dict[str | None, str | None] | None = None,
         dims: tuple[str, ...] = ("x", "y"),
         view: dict | None = None,
@@ -2567,6 +2860,11 @@ class Features:
         boundaries : list[str] | None
             Boundary names (or refs resolvable by ``_resolve_boundary_ref``)
             to draw. Order controls draw stacking.
+        axes : list[str] | None
+            Axis asset names (registered via :meth:`define_static_axis`,
+            :meth:`define_dynamic_axis`, or :meth:`import_static_axis`) to
+            draw as infinite lines clipped to the canvas boundary.
+            Styled via ``style["axes"]``.
         features : list[str | None] | dict[str | None, str | None] | None
             Per-frame scalar feature columns from ``self.data`` to render as
             text overlays. If a list is provided, each column is shown as
@@ -2650,6 +2948,15 @@ class Features:
             if boundaries is not None
             else []
         )
+        axis_arrays = (
+            self.axes_to_arrays(
+                axes,
+                dims=(dims[0], dims[1]),
+                undo_meta_scaling=undo_meta_scaling,
+            )
+            if axes is not None
+            else []
+        )
         text_overlays = None
         if features is not None:
             text_overlays = []
@@ -2686,6 +2993,7 @@ class Features:
             frame_ids=self.tracking.data.index.to_numpy(copy=True),
             fps=float(self.tracking.meta.get("fps", 30.0)),
             boundary_arrays=boundary_arrays,
+            axis_arrays=axis_arrays,
             canvas_size=canvas_size,
             bg_color=bg_color,
             style=style,
@@ -2782,3 +3090,57 @@ class Features:
                 )
                 boundary_arrays.append((boundary_name, poly_stack))
         return boundary_arrays
+
+    def axes_to_arrays(
+        self,
+        axes: list[str],
+        *,
+        dims: tuple[str, str] = ("x", "y"),
+        undo_meta_scaling: bool = False,
+    ) -> list[tuple[str, np.ndarray]]:
+        """Resolve named axis assets into per-axis reference-point arrays for animation.
+
+        Parameters
+        ----------
+        axes : list[str]
+            Axis asset names (registered via :meth:`define_static_axis`,
+            :meth:`define_dynamic_axis`, or :meth:`import_static_axis`).
+        dims : tuple[str, str], default ``("x", "y")``
+            Coordinate dimensions.  Must be a 2-tuple; axis asset dims must
+            match.
+        undo_meta_scaling : bool, default False
+            If True, invert tracking meta scaling before resolving coordinates.
+
+        Returns
+        -------
+        list[tuple[str, np.ndarray]]
+            Axis arrays as ``[(axis_name, arr), ...]`` where each arr has
+            shape ``(n_frames, 2, 2)``.
+        """
+        source_df = self.tracking.data
+        factors = (
+            self.tracking._undo_rescale_factors((dims[0], dims[1])) if undo_meta_scaling else {}
+        )
+        result: list[tuple[str, np.ndarray]] = []
+        for axis_ref in axes:
+            axis = self._resolve_axis_ref(axis_ref)
+            if axis.dims != dims:
+                raise ValueError(
+                    f"Axis {axis.name or axis_ref!r} dims {axis.dims} "
+                    f"do not match requested dims {dims}"
+                )
+            axis_name = str(axis_ref)
+            if isinstance(axis, StaticAxis):
+                seg = axis.to_numpy()  # (2, 2)
+                seg_stack = np.repeat(seg[np.newaxis, :, :], len(source_df), axis=0)
+            else:
+                seg_stack = axis.to_numpy_per_frame(source_df)  # (n, 2, 2)
+            seg_stack = rescale_array_by_dim(
+                seg_stack,
+                dims=(dims[0], dims[1]),
+                factors=factors,
+                dim_axis=2,
+                copy=False,
+            )
+            result.append((axis_name, seg_stack))
+        return result

--- a/src/py3r/behaviour/features/features.py
+++ b/src/py3r/behaviour/features/features.py
@@ -1232,11 +1232,23 @@ class Features:
         self,
         point: str,
         boundary: str | DynamicBoundary | StaticBoundary,
+        *,
+        signed: bool = False,
     ) -> FeaturesResult:
         """
         Main boundary distance API.
 
         Accepts a ``StaticBoundary`` or ``DynamicBoundary`` (or a stored boundary name).
+
+        Parameters
+        ----------
+        point :
+            Keypoint name whose coordinates are measured.
+        boundary :
+            A ``StaticBoundary``, ``DynamicBoundary``, or the string name of a stored boundary.
+        signed :
+            If ``True``, distances are negated for points inside the boundary (standard signed
+            distance field convention: negative = inside, positive = outside, zero = on boundary).
 
         Examples
         --------
@@ -1255,6 +1267,9 @@ class Features:
         >>> d2 = f.distance_to_boundary('p1', 'tri')
         >>> bool(isinstance(d2, pd.Series))
         True
+        >>> ds = f.distance_to_boundary('p1', b, signed=True)
+        >>> bool((ds <= 0).any() or (ds >= 0).any())
+        True
 
         ```
         """
@@ -1270,6 +1285,7 @@ class Features:
                 dims=boundary.dims,
                 boundary_label=boundary.name or self._short_boundary_id(list(boundary.vertices)),
                 boundary_meta=boundary.to_dict(),
+                signed=signed,
             )
         if isinstance(boundary, DynamicBoundary):
             return self._distance_to_boundary_dynamic_impl(
@@ -1283,10 +1299,11 @@ class Features:
                 else None,
                 boundary_label=boundary.name or self._short_boundary_id(list(boundary.points)),
                 boundary_meta=boundary.to_dict(),
+                signed=signed,
             )
         if isinstance(boundary, str):
             stored = self._resolve_boundary_ref(boundary)
-            return self.distance_to_boundary(point, stored)
+            return self.distance_to_boundary(point, stored, signed=signed)
         raise TypeError(
             "Unsupported boundary value. Expected StaticBoundary, DynamicBoundary, "
             "or stored boundary name."
@@ -1300,15 +1317,19 @@ class Features:
         dims: tuple[str, str],
         boundary_label: str,
         boundary_meta,
+        signed: bool = False,
     ) -> FeaturesResult:
         if len(boundary_vertices) < 3:
             raise Exception("boundary encloses no area")
         boundary_has_nan = any(pd.isna(bx) or pd.isna(by) for bx, by in boundary_vertices)
         name = f"distance_to_boundary_static_{point}_in_{boundary_label}"
+        if signed:
+            name += "_signed"
         meta = {
             "function": "distance_to_boundary",
             "point": point,
             "boundary": boundary_meta,
+            "signed": signed,
         }
 
         df = self.tracking.data
@@ -1319,11 +1340,14 @@ class Features:
         if boundary_has_nan:
             result = pd.Series(np.nan, index=df.index)
         else:
-            exterior = Polygon(boundary_vertices).exterior
+            poly = Polygon(boundary_vertices)
             result = pd.Series(np.nan, index=df.index)
             if valid.any():
                 pts = shapely.points(px[valid], py[valid])
-                result[valid] = shapely.distance(exterior, pts)
+                result[valid] = shapely.distance(poly.exterior, pts)
+                if signed:
+                    inside = shapely.within(pts, poly)
+                    result[valid] *= np.where(inside, -1.0, 1.0)
         return FeaturesResult(result, self, name, meta)
 
     def _distance_to_boundary_dynamic_impl(
@@ -1337,14 +1361,18 @@ class Features:
         anchor_points: list[str] | None,
         boundary_label: str,
         boundary_meta,
+        signed: bool = False,
     ) -> FeaturesResult:
         if len(boundary_points) < 3:
             raise Exception("boundary encloses no area")
         name = f"distance_to_boundary_dynamic_{point}_in_{boundary_label}"
+        if signed:
+            name += "_signed"
         meta = {
             "function": "distance_to_boundary",
             "point": point,
             "boundary": boundary_meta,
+            "signed": signed,
         }
 
         df = self.tracking.data
@@ -1377,6 +1405,9 @@ class Features:
             exteriors = shapely.get_exterior_ring(polys)
             pts = shapely.points(px[valid], py[valid])
             result[valid] = shapely.distance(exteriors, pts)
+            if signed:
+                inside = shapely.within(pts, polys)
+                result[valid] *= np.where(inside, -1.0, 1.0)
         return FeaturesResult(result, self, name, meta)
 
     def distance_to_boundary_static(

--- a/src/py3r/behaviour/util/dataframe_utils.py
+++ b/src/py3r/behaviour/util/dataframe_utils.py
@@ -175,6 +175,83 @@ def euclidean_distance(
     raise ValueError(f"Unknown method: {method}")
 
 
+def point_to_axis_distance(
+    P: np.ndarray,
+    A: np.ndarray,
+    B: np.ndarray,
+    *,
+    signed: bool = False,
+) -> np.ndarray:
+    """Compute framewise perpendicular distance from a point to an infinite axis.
+
+    The axis passes through A and B and extends infinitely in both directions.
+    All arrays must share the same shape ``(n_frames, n_dims)``.
+
+    Parameters
+    ----------
+    P : np.ndarray
+        Query point coordinates, shape ``(n_frames, n_dims)``.
+    A : np.ndarray
+        First axis reference point, shape ``(n_frames, n_dims)``.
+    B : np.ndarray
+        Second axis reference point, shape ``(n_frames, n_dims)``.
+    signed : bool, default False
+        If True, return a signed distance (2-D axes only).  Positive means P
+        is to the *right* when facing from A to B; negative means P is to the
+        *left*.  Raises ``ValueError`` for ``n_dims != 2`` when True.
+
+    Returns
+    -------
+    np.ndarray
+        Framewise (signed) perpendicular distances, shape ``(n_frames,)``.
+
+    Notes
+    -----
+    Degenerate frames where A == B (zero-length direction) return the distance
+    from P to A (unsigned) or zero (signed) without raising an error.
+
+    Examples
+    --------
+    ```pycon
+    >>> import numpy as np
+    >>> P = np.array([[0.0, 1.0], [3.0, 0.0], [0.0, -1.0]])
+    >>> A = np.array([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]])
+    >>> B = np.array([[1.0, 0.0], [1.0, 0.0], [1.0, 0.0]])
+    >>> point_to_axis_distance(P, A, B)
+    array([1., 0., 1.])
+    >>> point_to_axis_distance(P, A, B, signed=True)
+    array([-1.,  0.,  1.])
+
+    ```
+    """
+    AP = P - A  # (n, d)
+    AB = B - A  # (n, d)
+
+    ab_sq = np.sum(AB * AB, axis=1)  # (n,)
+
+    if signed:
+        n_dims = P.shape[1]
+        if n_dims != 2:
+            raise ValueError(f"signed=True requires a 2-D axis; got n_dims={n_dims}.")
+        # Signed distance = projection of AP onto the right-hand perpendicular
+        # of the unit direction d = AB / |AB|.
+        # perp_right = (d[1], -d[0])  →  AP · perp_right / |AB| * |AB| simplifies to:
+        #   (AP[0] * AB[1] - AP[1] * AB[0]) / |AB|
+        # Degenerate frames (A == B) → signed distance = 0.
+        ab_norm = np.sqrt(ab_sq)
+        with np.errstate(invalid="ignore", divide="ignore"):
+            cross = AP[:, 0] * AB[:, 1] - AP[:, 1] * AB[:, 0]
+            return np.where(ab_norm > 0, cross / ab_norm, 0.0)
+
+    # Scalar projection of P onto the infinite axis through A and B.
+    # Degenerate frames (A == B) get t = 0, i.e. closest point = A.
+    with np.errstate(invalid="ignore", divide="ignore"):
+        t = np.where(ab_sq > 0, np.sum(AP * AB, axis=1) / ab_sq, 0.0)
+
+    closest = A + t[:, np.newaxis] * AB  # (n, d)
+    return np.linalg.norm(P - closest, axis=1)  # (n,)
+
+
 def scale_columns(df: pd.DataFrame, factor: float, cols: Iterable[str]) -> pd.DataFrame:
     """
      Multiply selected DataFrame columns by a scalar factor.

--- a/tests/test_animation_stream.py
+++ b/tests/test_animation_stream.py
@@ -1,9 +1,11 @@
 import types
+import warnings
 
 import numpy as np
 import pandas as pd
 import pytest
 
+from py3r.behaviour.animation._projection import _clip_axis_to_canvas, _data_to_pixel_float
 from py3r.behaviour.animation.animation_stream import (
     _format_overlay_value,
     build_animation_stream,
@@ -443,3 +445,248 @@ def test_features_dynamic_boundary_style_na_behavior_matrix(
     assert frame0.shape == (48, 64, 3)
     frame1 = stream.get_frame(1)
     assert frame1.shape == (48, 64, 3)
+
+
+# ---------------------------------------------------------------------------
+# _clip_axis_to_canvas unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestClipAxisToCanvas:
+    """Unit tests for the canvas-edge clipping of an infinite axis."""
+
+    W, H = 64, 48
+
+    def test_horizontal_axis_clips_to_left_and_right_edges(self):
+        # Line through y=24, reference points outside canvas on both sides
+        p1, p2 = np.array([-10.0, 24.0]), np.array([90.0, 24.0])
+        result = _clip_axis_to_canvas(p1, p2, self.W, self.H)
+        assert result is not None
+        cp1, cp2 = result
+        assert cp1[1] == 24 and cp2[1] == 24
+        assert min(cp1[0], cp2[0]) == 0
+        assert max(cp1[0], cp2[0]) == self.W - 1
+
+    def test_vertical_axis_clips_to_top_and_bottom_edges(self):
+        p1, p2 = np.array([32.0, -10.0]), np.array([32.0, 58.0])
+        result = _clip_axis_to_canvas(p1, p2, self.W, self.H)
+        assert result is not None
+        cp1, cp2 = result
+        assert cp1[0] == 32 and cp2[0] == 32
+        assert min(cp1[1], cp2[1]) == 0
+        assert max(cp1[1], cp2[1]) == self.H - 1
+
+    def test_diagonal_spanning_canvas_corners(self):
+        p1, p2 = np.array([0.0, 0.0]), np.array([float(self.W - 1), float(self.H - 1)])
+        result = _clip_axis_to_canvas(p1, p2, self.W, self.H)
+        assert result is not None
+        pts = sorted([tuple(result[0]), tuple(result[1])])
+        assert pts[0] == (0, 0)
+        assert pts[1] == (self.W - 1, self.H - 1)
+
+    def test_axis_entirely_off_canvas_returns_none(self):
+        # Line from (-10, 60) to (20, 70): stays above (y > H−1) the canvas
+        p1, p2 = np.array([-10.0, 60.0]), np.array([20.0, 70.0])
+        result = _clip_axis_to_canvas(p1, p2, self.W, self.H)
+        assert result is None
+
+    def test_coincident_points_returns_none(self):
+        p = np.array([32.0, 24.0])
+        result = _clip_axis_to_canvas(p, p.copy(), self.W, self.H)
+        assert result is None
+
+    def test_reference_points_inside_canvas_still_works(self):
+        # Both reference points inside canvas: result should still be two canvas-edge points
+        p1, p2 = np.array([10.0, 24.0]), np.array([50.0, 24.0])
+        result = _clip_axis_to_canvas(p1, p2, self.W, self.H)
+        assert result is not None
+        cp1, cp2 = result
+        # Clipped endpoints should be on left and right edges for a horizontal axis
+        assert min(cp1[0], cp2[0]) == 0
+        assert max(cp1[0], cp2[0]) == self.W - 1
+
+
+# ---------------------------------------------------------------------------
+# _data_to_pixel_float unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestDataToPixelFloat:
+    def test_min_corner_maps_to_pixel_origin(self):
+        bounds = (0.0, 10.0, 0.0, 10.0)
+        pts = np.array([[0.0, 0.0]])
+        out = _data_to_pixel_float(pts, width=11, height=11, bounds=bounds, pixel_coords=False)
+        # x=0 → px=0; y=0 → py=height-1=10 (y-axis is flipped)
+        assert out[0, 0] == pytest.approx(0.0)
+        assert out[0, 1] == pytest.approx(10.0)
+
+    def test_max_corner_maps_to_pixel_max(self):
+        bounds = (0.0, 10.0, 0.0, 10.0)
+        pts = np.array([[10.0, 10.0]])
+        out = _data_to_pixel_float(pts, width=11, height=11, bounds=bounds, pixel_coords=False)
+        assert out[0, 0] == pytest.approx(10.0)
+        assert out[0, 1] == pytest.approx(0.0)
+
+    def test_pixel_coords_passthrough(self):
+        bounds = (0.0, 1.0, 0.0, 1.0)
+        pts = np.array([[15.7, 30.2]])
+        out = _data_to_pixel_float(pts, width=64, height=48, bounds=bounds, pixel_coords=True)
+        assert np.allclose(out, pts)
+
+    def test_out_of_bounds_values_preserved(self):
+        # Reference points well outside canvas range should keep their (large) pixel values
+        bounds = (0.0, 10.0, 0.0, 10.0)
+        pts = np.array([[-5.0, 15.0]])  # outside on both axes
+        out = _data_to_pixel_float(pts, width=64, height=48, bounds=bounds, pixel_coords=False)
+        # Should not be clipped; x should be negative, y should be negative
+        assert out[0, 0] < 0
+        assert out[0, 1] < 0
+
+
+# ---------------------------------------------------------------------------
+# Axis rendering via build_animation_stream
+# ---------------------------------------------------------------------------
+
+
+def _empty_points(n_frames: int) -> np.ndarray:
+    return np.empty((n_frames, 0, 2), dtype=float)
+
+
+def test_axis_array_renders_green_pixels_on_canvas():
+    # Horizontal axis through y=24 of a 64×48 canvas (pixel coords)
+    n = 3
+    axis_arr = np.tile(np.array([[[0.0, 24.0], [63.0, 24.0]]]), (n, 1, 1))
+    stream = build_animation_stream(
+        points=_empty_points(n),
+        point_names=[],
+        frame_ids=np.arange(n),
+        axis_arrays=[("midline", axis_arr)],
+        canvas_size=(64, 48),
+        pixel_coords=True,
+    )
+    frame = stream.get_frame(0)
+    assert frame.shape == (48, 64, 3)
+    # Default axis style is green (B=0, G=255, R=0 in BGR); row 24 should have green pixels
+    assert np.any(frame[24, :, 1] == 255)
+
+
+def test_axis_array_nan_reference_frame_renders_blank():
+    # Frame 0 has a NaN reference point; frame 1 is valid
+    axis_arr = np.array(
+        [
+            [[np.nan, 24.0], [63.0, 24.0]],  # invalid: NaN
+            [[0.0, 24.0], [63.0, 24.0]],  # valid
+        ],
+        dtype=float,
+    )
+    stream = build_animation_stream(
+        points=_empty_points(2),
+        point_names=[],
+        frame_ids=np.arange(2),
+        axis_arrays=[("midline", axis_arr)],
+        canvas_size=(64, 48),
+        pixel_coords=True,
+    )
+    frame0 = stream.get_frame(0)
+    frame1 = stream.get_frame(1)
+    assert np.all(frame0 == 0), "NaN frame should produce a blank canvas"
+    assert np.any(frame1 != 0), "Valid frame should have rendered pixels"
+
+
+def test_axis_reference_points_outside_canvas_still_renders():
+    # Vertical axis with reference points far above and below the canvas
+    n = 1
+    axis_arr = np.array([[[32.0, -1000.0], [32.0, 1000.0]]], dtype=float)
+    stream = build_animation_stream(
+        points=_empty_points(n),
+        point_names=[],
+        frame_ids=np.arange(n),
+        axis_arrays=[("vert", axis_arr)],
+        canvas_size=(64, 48),
+        pixel_coords=True,
+    )
+    frame = stream.get_frame(0)
+    # Column 32 should contain green pixels along its full height
+    assert np.any(frame[:, 32, 1] == 255)
+
+
+def test_axis_custom_style_applied():
+    n = 2
+    axis_arr = np.tile(np.array([[[0.0, 24.0], [63.0, 24.0]]]), (n, 1, 1))
+    stream = build_animation_stream(
+        points=_empty_points(n),
+        point_names=[],
+        frame_ids=np.arange(n),
+        axis_arrays=[("midline", axis_arr)],
+        canvas_size=(64, 48),
+        pixel_coords=True,
+        style={"axes": {"midline": {"edge_color": (255, 0, 0), "edge_width": 2}}},
+    )
+    frame = stream.get_frame(0)
+    # OpenCV uses BGR; (255, 0, 0) → blue (channel 0 = 255, channel 1 = 0)
+    assert np.any(frame[24, :, 0] == 255)
+    assert np.all(frame[24, frame[24, :, 0] == 255, 1] == 0)
+
+
+def test_axis_edge_width_zero_produces_blank_canvas():
+    n = 1
+    axis_arr = np.array([[[0.0, 24.0], [63.0, 24.0]]], dtype=float)
+    stream = build_animation_stream(
+        points=_empty_points(n),
+        point_names=[],
+        frame_ids=np.arange(n),
+        axis_arrays=[("midline", axis_arr)],
+        canvas_size=(64, 48),
+        pixel_coords=True,
+        style={"axes": {"midline": {"edge_width": 0}}},
+    )
+    frame = stream.get_frame(0)
+    assert np.all(frame == 0)
+
+
+def test_multiple_axis_arrays_all_rendered():
+    n = 1
+    h_axis = np.array([[[0.0, 16.0], [63.0, 16.0]]], dtype=float)
+    v_axis = np.array([[[32.0, 0.0], [32.0, 47.0]]], dtype=float)
+    stream = build_animation_stream(
+        points=_empty_points(n),
+        point_names=[],
+        frame_ids=np.arange(n),
+        axis_arrays=[("h", h_axis), ("v", v_axis)],
+        canvas_size=(64, 48),
+        pixel_coords=True,
+    )
+    frame = stream.get_frame(0)
+    # Row 16 should have green (horizontal axis)
+    assert np.any(frame[16, :, 1] == 255)
+    # Column 32 should have green (vertical axis)
+    assert np.any(frame[:, 32, 1] == 255)
+
+
+def test_features_animation_stream_axes_param():
+    """Features.animation_stream accepts axes= and renders the axis."""
+    df = pd.DataFrame(
+        {
+            "a.x": [0.0, 0.0, 0.0],
+            "a.y": [24.0, 24.0, 24.0],
+            "b.x": [63.0, 63.0, 63.0],
+            "b.y": [24.0, 24.0, 24.0],
+            "q.x": [32.0, 32.0, 32.0],
+            "q.y": [30.0, 30.0, 30.0],
+        },
+        index=pd.RangeIndex(3, name="frame"),
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        t = Tracking(df, {"fps": 30.0}, handle="demo")
+    f = Features(t)
+    f.define_static_axis("a", "b", name="midline")
+    stream = f.animation_stream(
+        points=[],
+        axes=["midline"],
+        canvas_size=(64, 48),
+        pixel_coords=True,
+    )
+    frame = stream.get_frame(0)
+    assert frame.shape == (48, 64, 3)
+    assert np.any(frame != 0)

--- a/tests/test_features_axis.py
+++ b/tests/test_features_axis.py
@@ -1,0 +1,529 @@
+"""Tests for the axis asset API in Features.
+
+Covers:
+  - StaticAxis / DynamicAxis factory methods and offset transform helpers
+  - Generic asset access (get_asset, list_assets, _resolve_axis_ref)
+  - Type guards: within_boundary / distance_to_boundary reject axis objects
+  - distance_to_axis: unsigned (2-D and 3-D), signed (2-D), error paths
+  - Serialisation: to_dict / from_dict roundtrip for both axis types
+  - axes_to_arrays: shapes and per-frame values
+"""
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from py3r.behaviour.features.axis import (
+    DynamicAxis,
+    StaticAxis,
+    _transform_axis_endpoints,
+    _transform_axis_per_frame,
+)
+from py3r.behaviour.features.features import Features
+from py3r.behaviour.tracking.tracking import Tracking
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_tracking_2d():
+    """4-frame session with a horizontal axis (a→b along y=5) and a query point.
+
+    Frame layout:
+      frame 0: q above the axis  →  unsigned dist = 3, signed = −3 (left)
+      frame 1: q on the axis     →  unsigned dist = 0, signed = 0
+      frame 2: q below the axis  →  unsigned dist = 3, signed = +3 (right)
+      frame 3: axis ref pts NaN  →  distance should be NaN
+    """
+    data = pd.DataFrame(
+        {
+            "a.x": [0.0, 0.0, 0.0, np.nan],
+            "a.y": [5.0, 5.0, 5.0, 5.0],
+            "b.x": [10.0, 10.0, 10.0, np.nan],
+            "b.y": [5.0, 5.0, 5.0, 5.0],
+            "q.x": [5.0, 5.0, 5.0, 5.0],
+            "q.y": [8.0, 5.0, 2.0, 3.0],
+        },
+        index=pd.RangeIndex(4, name="frame"),
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return Tracking(data, {"fps": 30.0}, handle="test")
+
+
+def _make_tracking_3d():
+    """2-frame session with a 3-D axis and a query point."""
+    data = pd.DataFrame(
+        {
+            "a.x": [0.0, 0.0],
+            "a.y": [0.0, 0.0],
+            "a.z": [0.0, 0.0],
+            "b.x": [1.0, 1.0],
+            "b.y": [0.0, 0.0],
+            "b.z": [0.0, 0.0],
+            # q at (0, 3, 4): perpendicular distance to x-axis = sqrt(9+16)=5
+            "q.x": [0.0, 0.0],
+            "q.y": [3.0, 3.0],
+            "q.z": [4.0, 4.0],
+        },
+        index=pd.RangeIndex(2, name="frame"),
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return Tracking(data, {"fps": 30.0}, handle="test3d")
+
+
+@pytest.fixture
+def f2d():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return Features(_make_tracking_2d())
+
+
+@pytest.fixture
+def f3d():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return Features(_make_tracking_3d())
+
+
+# ---------------------------------------------------------------------------
+# Transform helpers
+# ---------------------------------------------------------------------------
+
+
+class TestTransformAxisEndpoints:
+    def test_zero_offset_returns_copy(self):
+        A = np.array([0.0, 0.0])
+        B = np.array([10.0, 0.0])
+        At, Bt = _transform_axis_endpoints(A, B, offset=0.0)
+        assert np.allclose(At, A)
+        assert np.allclose(Bt, B)
+
+    def test_positive_offset_shifts_right(self):
+        # Rightward axis A=(0,0)→B=(10,0); right-hand perp = (0,−1)
+        A = np.array([0.0, 0.0])
+        B = np.array([10.0, 0.0])
+        At, Bt = _transform_axis_endpoints(A, B, offset=2.0)
+        assert np.allclose(At, [0.0, -2.0])
+        assert np.allclose(Bt, [10.0, -2.0])
+
+    def test_negative_offset_shifts_left(self):
+        A = np.array([0.0, 0.0])
+        B = np.array([10.0, 0.0])
+        At, Bt = _transform_axis_endpoints(A, B, offset=-3.0)
+        assert np.allclose(At, [0.0, 3.0])
+        assert np.allclose(Bt, [10.0, 3.0])
+
+    def test_non_2d_with_offset_raises(self):
+        A = np.array([0.0, 0.0, 0.0])
+        B = np.array([1.0, 0.0, 0.0])
+        with pytest.raises(ValueError, match="2-D"):
+            _transform_axis_endpoints(A, B, offset=1.0)
+
+    def test_degenerate_axis_with_offset_raises(self):
+        A = np.array([5.0, 5.0])
+        with pytest.raises(ValueError, match="zero-length"):
+            _transform_axis_endpoints(A, A.copy(), offset=1.0)
+
+
+class TestTransformAxisPerFrame:
+    def test_zero_offset_returns_copy(self):
+        arr = np.array([[[0.0, 0.0], [10.0, 0.0]], [[1.0, 1.0], [11.0, 1.0]]], dtype=float)
+        out = _transform_axis_per_frame(arr, offset=0.0)
+        assert np.allclose(out, arr)
+        assert out is not arr
+
+    def test_positive_offset_shifts_right_per_frame(self):
+        # Rightward axis each frame; perp_right = (0,−1); offset=2 → shift (0,−2)
+        arr = np.zeros((3, 2, 2), dtype=float)
+        arr[:, 1, 0] = 10.0  # B.x = 10 for all frames
+        out = _transform_axis_per_frame(arr, offset=2.0)
+        assert np.allclose(out[:, 0, 1], -2.0)  # A.y shifted to −2
+        assert np.allclose(out[:, 1, 1], -2.0)  # B.y shifted to −2
+
+    def test_degenerate_frame_gets_zero_shift(self):
+        # A == B for frame 0 → no shift, no error
+        arr = np.zeros((2, 2, 2), dtype=float)
+        arr[1, 1, 0] = 10.0  # only frame 1 has a valid direction
+        out = _transform_axis_per_frame(arr, offset=2.0)
+        assert np.allclose(out[0], 0.0)  # degenerate: no shift applied
+
+    def test_non_2d_with_offset_raises(self):
+        arr = np.zeros((2, 2, 3), dtype=float)
+        with pytest.raises(ValueError, match="2-D"):
+            _transform_axis_per_frame(arr, offset=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Factory: define_static_axis
+# ---------------------------------------------------------------------------
+
+
+class TestDefineStaticAxis:
+    def test_returns_static_axis(self, f2d):
+        ax = f2d.define_static_axis("a", "b")
+        assert isinstance(ax, StaticAxis)
+
+    def test_vertices_match_medians(self, f2d):
+        ax = f2d.define_static_axis("a", "b")
+        # Median of a: x=0, y=5; median of b: x=10, y=5 (frame 3 NaN ignored)
+        assert np.allclose(ax.vertices[0], [0.0, 5.0])
+        assert np.allclose(ax.vertices[1], [10.0, 5.0])
+
+    def test_source_points_recorded(self, f2d):
+        ax = f2d.define_static_axis("a", "b")
+        assert ax.source_points == ("a", "b")
+
+    def test_dims_stored(self, f2d):
+        ax = f2d.define_static_axis("a", "b", dims=("x", "y"))
+        assert ax.dims == ("x", "y")
+
+    def test_registered_by_name(self, f2d):
+        ax = f2d.define_static_axis("a", "b", name="midline")
+        assert f2d.get_asset("midline") is ax
+
+    def test_offset_baked_into_vertices(self, f2d):
+        ax = f2d.define_static_axis("a", "b", offset=2.0)
+        # Rightward axis along y=5; perp_right=(0,−1); offset=2 → y shifts to 3
+        assert np.allclose(ax.vertices[0][1], 3.0)
+        assert np.allclose(ax.vertices[1][1], 3.0)
+
+    def test_overwrite_false_raises_on_duplicate(self, f2d):
+        f2d.define_static_axis("a", "b", name="ax")
+        with pytest.raises(ValueError, match="already exists"):
+            f2d.define_static_axis("a", "b", name="ax", overwrite=False)
+
+    def test_overwrite_true_replaces(self, f2d):
+        f2d.define_static_axis("a", "b", name="ax")
+        ax2 = f2d.define_static_axis("a", "b", offset=1.0, name="ax", overwrite=True)
+        assert f2d.get_asset("ax") is ax2
+
+
+# ---------------------------------------------------------------------------
+# Factory: import_static_axis
+# ---------------------------------------------------------------------------
+
+
+class TestImportStaticAxis:
+    def test_returns_static_axis(self, f2d):
+        ax = f2d.import_static_axis([(0.0, 0.0), (1.0, 0.0)])
+        assert isinstance(ax, StaticAxis)
+
+    def test_vertices_stored(self, f2d):
+        ax = f2d.import_static_axis([(1.0, 2.0), (3.0, 4.0)], name="custom")
+        assert ax.vertices == ((1.0, 2.0), (3.0, 4.0))
+
+    def test_wrong_vertex_count_raises(self, f2d):
+        with pytest.raises(ValueError, match="2 reference points"):
+            f2d.import_static_axis([(0.0, 0.0)])
+
+    def test_three_vertices_raises(self, f2d):
+        with pytest.raises(ValueError, match="2 reference points"):
+            f2d.import_static_axis([(0, 0), (1, 0), (2, 0)])
+
+
+# ---------------------------------------------------------------------------
+# Factory: define_dynamic_axis
+# ---------------------------------------------------------------------------
+
+
+class TestDefineDynamicAxis:
+    def test_returns_dynamic_axis(self, f2d):
+        ax = f2d.define_dynamic_axis("a", "b")
+        assert isinstance(ax, DynamicAxis)
+
+    def test_points_stored(self, f2d):
+        ax = f2d.define_dynamic_axis("a", "b")
+        assert ax.points == ("a", "b")
+
+    def test_dims_stored(self, f2d):
+        ax = f2d.define_dynamic_axis("a", "b", dims=("x", "y"))
+        assert ax.dims == ("x", "y")
+
+    def test_offset_stored(self, f2d):
+        ax = f2d.define_dynamic_axis("a", "b", offset=1.5)
+        assert ax.offset == pytest.approx(1.5)
+
+    def test_default_offset_is_zero(self, f2d):
+        ax = f2d.define_dynamic_axis("a", "b")
+        assert ax.offset == 0.0
+
+    def test_registered_by_name(self, f2d):
+        ax = f2d.define_dynamic_axis("a", "b", name="dyn_ax")
+        assert f2d.get_asset("dyn_ax") is ax
+
+
+# ---------------------------------------------------------------------------
+# Asset access
+# ---------------------------------------------------------------------------
+
+
+class TestAssetAccess:
+    def test_get_asset_returns_registered_axis(self, f2d):
+        ax = f2d.define_static_axis("a", "b", name="midline")
+        assert f2d.get_asset("midline") is ax
+
+    def test_list_assets_includes_axis(self, f2d):
+        f2d.define_static_axis("a", "b", name="midline")
+        tbl = f2d.list_assets()
+        assert "midline" in tbl.index
+        assert tbl.loc["midline", "asset_type"] == "StaticAxis"
+
+    def test_list_assets_includes_dynamic_axis(self, f2d):
+        f2d.define_dynamic_axis("a", "b", name="dyn")
+        tbl = f2d.list_assets()
+        assert tbl.loc["dyn", "asset_type"] == "DynamicAxis"
+
+    def test_resolve_axis_ref_by_name(self, f2d):
+        ax = f2d.define_static_axis("a", "b", name="midline")
+        assert f2d._resolve_axis_ref("midline") is ax
+
+    def test_resolve_axis_ref_by_object(self, f2d):
+        ax = f2d.define_static_axis("a", "b")
+        assert f2d._resolve_axis_ref(ax) is ax
+
+    def test_resolve_axis_ref_rejects_boundary(self, f2d):
+        f2d.define_static_boundary(["a", "b", "q"], name="tri")
+        with pytest.raises(TypeError, match="StaticAxis"):
+            f2d._resolve_axis_ref("tri")
+
+    def test_within_boundary_rejects_axis(self, f2d):
+        ax = f2d.define_static_axis("a", "b")
+        with pytest.raises(TypeError, match="distance_to_axis"):
+            f2d.within_boundary("q", ax)
+
+    def test_distance_to_boundary_rejects_axis(self, f2d):
+        ax = f2d.define_dynamic_axis("a", "b")
+        with pytest.raises(TypeError, match="distance_to_axis"):
+            f2d.distance_to_boundary("q", ax)
+
+
+# ---------------------------------------------------------------------------
+# distance_to_axis: unsigned
+# ---------------------------------------------------------------------------
+
+
+class TestDistanceToAxisUnsigned:
+    def test_static_axis_above(self, f2d):
+        ax = f2d.define_static_axis("a", "b")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            res = f2d.distance_to_axis("q", ax)
+        assert res.iloc[0] == pytest.approx(3.0)
+
+    def test_static_axis_on_axis(self, f2d):
+        ax = f2d.define_static_axis("a", "b")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            res = f2d.distance_to_axis("q", ax)
+        assert res.iloc[1] == pytest.approx(0.0)
+
+    def test_static_axis_below(self, f2d):
+        ax = f2d.define_static_axis("a", "b")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            res = f2d.distance_to_axis("q", ax)
+        assert res.iloc[2] == pytest.approx(3.0)
+
+    def test_dynamic_axis_matches_static(self, f2d):
+        static_ax = f2d.define_static_axis("a", "b")
+        dyn_ax = f2d.define_dynamic_axis("a", "b")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            res_s = f2d.distance_to_axis("q", static_ax)
+            res_d = f2d.distance_to_axis("q", dyn_ax)
+        # Frames 0-2: identical (frame 3 has NaN ref pts, dyn will be NaN)
+        assert res_s.iloc[0] == pytest.approx(res_d.iloc[0])
+        assert res_s.iloc[1] == pytest.approx(res_d.iloc[1])
+
+    def test_dynamic_axis_nan_ref_pts_gives_nan(self, f2d):
+        dyn_ax = f2d.define_dynamic_axis("a", "b")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            res = f2d.distance_to_axis("q", dyn_ax)
+        assert np.isnan(res.iloc[3])
+
+    def test_3d_axis_distance(self, f3d):
+        ax = f3d.define_static_axis("a", "b", dims=("x", "y", "z"))
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            res = f3d.distance_to_axis("q", ax)
+        assert res.iloc[0] == pytest.approx(5.0)
+
+    def test_result_length_matches_tracking(self, f2d):
+        ax = f2d.define_static_axis("a", "b")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            res = f2d.distance_to_axis("q", ax)
+        assert len(res) == len(f2d.tracking.data)
+
+    def test_accepts_axis_by_name(self, f2d):
+        f2d.define_static_axis("a", "b", name="midline")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            res = f2d.distance_to_axis("q", "midline")
+        assert res.iloc[0] == pytest.approx(3.0)
+
+    def test_result_name_format(self, f2d):
+        f2d.define_static_axis("a", "b", name="midline")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            res = f2d.distance_to_axis("q", "midline")
+        assert "distance_to_axis" in res.name
+        assert "midline" in res.name
+        assert "_signed" not in res.name
+
+
+# ---------------------------------------------------------------------------
+# distance_to_axis: signed
+# ---------------------------------------------------------------------------
+
+
+class TestDistanceToAxisSigned:
+    def test_positive_right_of_axis(self, f2d):
+        # frame 2: q below the rightward axis → right → positive
+        ax = f2d.define_static_axis("a", "b")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            res = f2d.distance_to_axis("q", ax, signed=True)
+        assert res.iloc[2] == pytest.approx(3.0)
+
+    def test_negative_left_of_axis(self, f2d):
+        # frame 0: q above the rightward axis → left → negative
+        ax = f2d.define_static_axis("a", "b")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            res = f2d.distance_to_axis("q", ax, signed=True)
+        assert res.iloc[0] == pytest.approx(-3.0)
+
+    def test_zero_on_axis(self, f2d):
+        ax = f2d.define_static_axis("a", "b")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            res = f2d.distance_to_axis("q", ax, signed=True)
+        assert res.iloc[1] == pytest.approx(0.0)
+
+    def test_signed_magnitude_equals_unsigned_off_axis(self, f2d):
+        ax = f2d.define_static_axis("a", "b")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            unsigned = f2d.distance_to_axis("q", ax, signed=False)
+            signed = f2d.distance_to_axis("q", ax, signed=True)
+        assert abs(signed.iloc[0]) == pytest.approx(unsigned.iloc[0])
+        assert abs(signed.iloc[2]) == pytest.approx(unsigned.iloc[2])
+
+    def test_signed_3d_raises(self, f3d):
+        ax = f3d.define_static_axis("a", "b", dims=("x", "y", "z"))
+        with pytest.raises(ValueError, match="signed=True requires a 2-D"):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                f3d.distance_to_axis("q", ax, signed=True)
+
+    def test_signed_result_name_has_suffix(self, f2d):
+        f2d.define_static_axis("a", "b", name="midline")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            res = f2d.distance_to_axis("q", "midline", signed=True)
+        assert "_signed" in res.name
+
+    def test_signed_meta_flag(self, f2d):
+        ax = f2d.define_static_axis("a", "b")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            res = f2d.distance_to_axis("q", ax, signed=True)
+        assert res._params["signed"] is True
+
+    def test_unsigned_meta_flag(self, f2d):
+        ax = f2d.define_static_axis("a", "b")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            res = f2d.distance_to_axis("q", ax, signed=False)
+        assert res._params["signed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Serialisation
+# ---------------------------------------------------------------------------
+
+
+class TestAxisSerialisation:
+    def test_static_axis_kind_string(self, f2d):
+        ax = f2d.define_static_axis("a", "b")
+        assert ax.to_dict()["kind"] == "static_axis"
+
+    def test_dynamic_axis_kind_string(self, f2d):
+        ax = f2d.define_dynamic_axis("a", "b")
+        assert ax.to_dict()["kind"] == "dynamic_axis"
+
+    def test_static_axis_roundtrip(self, f2d):
+        ax = f2d.define_static_axis("a", "b", name="midline", offset=1.0)
+        d = ax.to_dict()
+        ax2 = StaticAxis.from_dict(d)
+        assert ax2.dims == ax.dims
+        assert ax2.name == ax.name
+        assert np.allclose(ax2.vertices[0], ax.vertices[0])
+        assert np.allclose(ax2.vertices[1], ax.vertices[1])
+
+    def test_dynamic_axis_roundtrip(self, f2d):
+        ax = f2d.define_dynamic_axis("a", "b", offset=2.5, name="dyn")
+        d = ax.to_dict()
+        ax2 = DynamicAxis.from_dict(d)
+        assert ax2.points == ax.points
+        assert ax2.dims == ax.dims
+        assert ax2.offset == pytest.approx(ax.offset)
+        assert ax2.name == ax.name
+
+    def test_static_axis_source_points_preserved(self, f2d):
+        ax = f2d.define_static_axis("a", "b")
+        d = ax.to_dict()
+        ax2 = StaticAxis.from_dict(d)
+        assert ax2.source_points == ("a", "b")
+
+
+# ---------------------------------------------------------------------------
+# axes_to_arrays
+# ---------------------------------------------------------------------------
+
+
+class TestAxesToArrays:
+    def test_static_axis_shape(self, f2d):
+        f2d.define_static_axis("a", "b", name="midline")
+        arrays = f2d.axes_to_arrays(["midline"])
+        assert len(arrays) == 1
+        name, arr = arrays[0]
+        assert name == "midline"
+        assert arr.shape == (len(f2d.tracking.data), 2, 2)
+
+    def test_static_axis_constant_across_frames(self, f2d):
+        f2d.define_static_axis("a", "b", name="midline")
+        _, arr = f2d.axes_to_arrays(["midline"])[0]
+        # All frames should be identical for a static axis
+        assert np.allclose(arr[0], arr[1])
+        assert np.allclose(arr[0], arr[2])
+
+    def test_dynamic_axis_shape(self, f2d):
+        f2d.define_dynamic_axis("a", "b", name="dyn")
+        _, arr = f2d.axes_to_arrays(["dyn"])[0]
+        assert arr.shape == (len(f2d.tracking.data), 2, 2)
+
+    def test_dynamic_axis_varies_with_data(self, f2d):
+        # frames 0–2 have the same a/b coords, so arrays are equal
+        # frame 3 has NaN → should propagate
+        f2d.define_dynamic_axis("a", "b", name="dyn")
+        _, arr = f2d.axes_to_arrays(["dyn"])[0]
+        assert np.isnan(arr[3, 0, 0])  # a.x is NaN in frame 3
+
+    def test_dims_mismatch_raises(self, f2d):
+        f2d.define_static_axis("a", "b", dims=("x", "y"), name="midline")
+        with pytest.raises(ValueError, match="dims"):
+            f2d.axes_to_arrays(["midline"], dims=("x", "z"))
+
+    def test_multiple_axes_returned_in_order(self, f2d):
+        f2d.define_static_axis("a", "b", name="ax1")
+        f2d.define_dynamic_axis("a", "b", name="ax2")
+        arrays = f2d.axes_to_arrays(["ax1", "ax2"])
+        assert [name for name, _ in arrays] == ["ax1", "ax2"]

--- a/tests/test_features_boundary.py
+++ b/tests/test_features_boundary.py
@@ -173,3 +173,86 @@ class TestDistanceToBoundaryNewApi:
     def test_rejects_legacy_vertex_list(self, features):
         with pytest.raises(TypeError, match="Unsupported boundary value"):
             features.distance_to_boundary("q", STATIC_BOUNDARY)
+
+
+# Triangle [(0,0),(10,0),(0,10)]:
+#   frame 0  q=(3,3)   inside  – nearest edge is hypotenuse x+y=10, dist = 4/√2 = 2√2
+#   frame 1  q=(20,20) outside – nearest edge is hypotenuse,         dist = 30/√2 = 15√2
+#   frame 7  q=(5,0)   on edge – distance = 0, within() is strict False → signed = 0
+_INSIDE_DIST = 2 * np.sqrt(2)
+_OUTSIDE_DIST = 15 * np.sqrt(2)
+
+
+class TestDistanceToBoundarySignedArg:
+    # --- static boundary ---
+
+    def test_static_inside_is_negative(self, features):
+        boundary = features.define_static_boundary(BOUNDARY_NAMES)
+        res = features.distance_to_boundary("q", boundary, signed=True)
+        assert res.iloc[0] == pytest.approx(-_INSIDE_DIST)
+
+    def test_static_outside_is_positive(self, features):
+        boundary = features.define_static_boundary(BOUNDARY_NAMES)
+        res = features.distance_to_boundary("q", boundary, signed=True)
+        assert res.iloc[1] == pytest.approx(_OUTSIDE_DIST)
+
+    def test_static_on_boundary_is_zero(self, features):
+        boundary = features.define_static_boundary(BOUNDARY_NAMES)
+        res = features.distance_to_boundary("q", boundary, signed=True)
+        assert res.iloc[7] == pytest.approx(0.0)
+
+    def test_static_nan_propagates(self, features):
+        boundary = features.define_static_boundary(BOUNDARY_NAMES)
+        res = features.distance_to_boundary("q", boundary, signed=True)
+        # frames 2 (q.x NaN), 3 (q.y NaN), 4 (both NaN) must stay NaN
+        assert np.isnan(res.iloc[2])
+        assert np.isnan(res.iloc[3])
+        assert np.isnan(res.iloc[4])
+
+    def test_static_abs_equals_unsigned(self, features):
+        boundary = features.define_static_boundary(BOUNDARY_NAMES)
+        unsigned = features.distance_to_boundary("q", boundary)
+        signed = features.distance_to_boundary("q", boundary, signed=True)
+        valid = ~unsigned.isna()
+        np.testing.assert_allclose(signed[valid].abs().to_numpy(), unsigned[valid].to_numpy())
+
+    # --- dynamic boundary ---
+
+    def test_dynamic_inside_is_negative(self, features):
+        boundary = features.define_dynamic_boundary(BOUNDARY_NAMES)
+        res = features.distance_to_boundary("q", boundary, signed=True)
+        assert res.iloc[0] == pytest.approx(-_INSIDE_DIST)
+
+    def test_dynamic_outside_is_positive(self, features):
+        boundary = features.define_dynamic_boundary(BOUNDARY_NAMES)
+        res = features.distance_to_boundary("q", boundary, signed=True)
+        assert res.iloc[1] == pytest.approx(_OUTSIDE_DIST)
+
+    def test_dynamic_nan_propagates(self, features):
+        boundary = features.define_dynamic_boundary(BOUNDARY_NAMES)
+        res = features.distance_to_boundary("q", boundary, signed=True)
+        assert np.isnan(res.iloc[2])
+        assert np.isnan(res.iloc[5])  # b3 vertex NaN at frame 5
+        assert np.isnan(res.iloc[6])  # all NaN at frame 6
+
+    def test_dynamic_abs_equals_unsigned(self, features):
+        boundary = features.define_dynamic_boundary(BOUNDARY_NAMES)
+        unsigned = features.distance_to_boundary("q", boundary)
+        signed = features.distance_to_boundary("q", boundary, signed=True)
+        valid = ~unsigned.isna()
+        np.testing.assert_allclose(signed[valid].abs().to_numpy(), unsigned[valid].to_numpy())
+
+    # --- stored boundary name ---
+
+    def test_stored_name_forwards_signed(self, features):
+        features.define_static_boundary(BOUNDARY_NAMES, name="tri_s", overwrite=True)
+        res = features.distance_to_boundary("q", "tri_s", signed=True)
+        assert res.iloc[0] == pytest.approx(-_INSIDE_DIST)
+        assert res.iloc[1] == pytest.approx(_OUTSIDE_DIST)
+
+    # --- default unchanged ---
+
+    def test_default_is_unsigned(self, features):
+        boundary = features.define_static_boundary(BOUNDARY_NAMES)
+        res = features.distance_to_boundary("q", boundary)
+        assert (res.dropna() >= 0).all()


### PR DESCRIPTION
### Summary
<!-- 
A short description of what this PR does.

Example:
- Adds aggregation functions for multi-animal keypoint trajectories.
-->
- New `StaticAxis` / `DynamicAxis` dataclasses (`features/axis.py`) : two-point
  geometric assets registered in the generic `_ASSET_KINDS` registry alongside boundaries.
- `Features` factory methods: `define_static_axis`, `define_dynamic_axis`, `import_static_axis`;
  support an `offset` parameter that shifts the axis perpendicularly at definition time (static)
  or per-frame (dynamic). Axes are always infinite.
- `Features.distance_to_axis(point, axis, *, signed=False)`: framewise perpendicular distance
  to the infinite axis; `signed=True` (2-D only) returns positive right / negative left of the
  A→B direction, consistent with the `offset` sign convention.
- Animation: axes render as canvas-spanning lines clipped to the canvas boundary
  (`_clip_axis_to_canvas`), so reference points outside the canvas still produce a full crossing
  line. Styled via `style["axes"]`. Exposed via `Features.animation_stream(axes=[...])`.
- Boundaries and axes now sit within flat dict in `_assets` attribute of `Features` object, new method `list_assets` returns df of all assets indicating type; serialisation (in load/save) uses object type rather than dict structure. Note that this also means boundaries and axes can not have name collisions (which is good practice anyway).
- Added keyword-only `signed: bool = False` argument to `Features.distance_to_boundary` following the same pattern. Points inside the boundary return negative distances, outside positive.

### Type of change
<!-- 
At least one MUST be checked.
Use lowercase x exactly like this: [x]
-->
- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🧹 Chore / Refactor
- [ ] 📚 Docs

### User-facing change
<!-- 
This is what will appear in the release notes.
Write as a single bullet starting with - 

Example:
- Fixed incorrect body-angle computation when animals rotate >180°.
-->
- New `axis` assets (similar to existing `boundary` assets) defined statically/dynamically by two points, extending with infinite length. Support `distance_to_axis` calculations (signed or unsigned). `distance_to_boundary` now also optionally supports signed distances.

### Testing
<!-- 
Explain how you tested the change.

Example:
- Added docstring tests covering interpolation of missing keypoints.
-->
- unit tests, bespoke tests
