### PR TITLE
axis intersects boundary and related fixes

### DIFF
--- a/src/py3r/behaviour/features/boundary.py
+++ b/src/py3r/behaviour/features/boundary.py
@@ -99,13 +99,14 @@ class DynamicBoundary:
         }
 
     def to_numpy_per_frame(self, tracking_df) -> np.ndarray:
-        """
-        Resolve dynamic boundary point names against tracking data.
+        """Resolve dynamic boundary point names against tracking data and apply scaling.
 
         Returns
         -------
         np.ndarray
-            Shape (n_frames, n_vertices, 2) in this boundary's ``dims``.
+            Shape ``(n_frames, n_vertices, 2)`` in this boundary's ``dims``,
+            with ``scale_dim1`` / ``scale_dim2`` applied around the centroid
+            (or ``anchor_points`` centroid when specified).
         """
         cols_per_point = []
         for point in self.points:
@@ -123,7 +124,34 @@ class DynamicBoundary:
                     )
                 )
             )
-        return np.stack(cols_per_point, axis=1)
+        verts = np.stack(cols_per_point, axis=1)  # (n_frames, n_vertices, 2)
+
+        if self.scale_dim1 == 1.0 and self.scale_dim2 == 1.0:
+            return verts
+
+        if self.anchor_points is None:
+            cx = np.nanmean(verts[:, :, 0], axis=1, keepdims=True)  # (n, 1)
+            cy = np.nanmean(verts[:, :, 1], axis=1, keepdims=True)
+        else:
+            anchor_x = np.column_stack(
+                [
+                    tracking_df[f"{a}.{self.dims[0]}"].to_numpy(dtype=float)
+                    for a in self.anchor_points
+                ]
+            )
+            anchor_y = np.column_stack(
+                [
+                    tracking_df[f"{a}.{self.dims[1]}"].to_numpy(dtype=float)
+                    for a in self.anchor_points
+                ]
+            )
+            cx = np.nanmean(anchor_x, axis=1, keepdims=True)
+            cy = np.nanmean(anchor_y, axis=1, keepdims=True)
+
+        scaled = verts.copy()
+        scaled[:, :, 0] = cx + (verts[:, :, 0] - cx) * self.scale_dim1
+        scaled[:, :, 1] = cy + (verts[:, :, 1] - cy) * self.scale_dim2
+        return scaled
 
     @classmethod
     def from_dict(cls, payload: dict) -> DynamicBoundary:

--- a/src/py3r/behaviour/features/features.py
+++ b/src/py3r/behaviour/features/features.py
@@ -54,6 +54,76 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 
+def _axis_boundary_intersections(
+    A: np.ndarray,
+    B: np.ndarray,
+    verts: np.ndarray,
+    zones: set[str],
+    *,
+    eps: float = 1e-10,
+) -> np.ndarray:
+    """Per-frame boolean: does the axis intersect the boundary in any of the given zones?
+
+    Parameters
+    ----------
+    A, B : np.ndarray, shape (n, 2)
+        Axis reference points per frame.
+    verts : np.ndarray
+        Either shape ``(N_verts, 2)`` for a static boundary or
+        ``(n, N_verts, 2)`` for a dynamic boundary.
+    zones : set of {"front", "within", "behind"}
+        Which zones count as an intersection.  Zones are defined by the scalar
+        projection parameter *t* of the intersection point onto A→B:
+
+        - ``"behind"``: t ≤ 0  (at or before A)
+        - ``"within"``: 0 < t < 1  (strictly between A and B)
+        - ``"front"``:  t ≥ 1  (at or beyond B)
+    eps : float
+        Tolerance for near-parallel axis/edge pairs (treated as no intersection).
+
+    Returns
+    -------
+    np.ndarray of bool, shape (n,)
+    """
+    static_boundary = verts.ndim == 2
+    n_verts = verts.shape[0] if static_boundary else verts.shape[1]
+    d = B - A  # (n, 2)
+    result = np.zeros(len(A), dtype=bool)
+
+    for i in range(n_verts):
+        if static_boundary:
+            V0 = verts[i]
+            V1 = verts[(i + 1) % n_verts]
+            e = V1 - V0  # (2,)
+            f = V0 - A  # (n, 2)
+            det = d[:, 1] * e[0] - d[:, 0] * e[1]
+            t_num = e[0] * f[:, 1] - e[1] * f[:, 0]
+            s_num = d[:, 0] * f[:, 1] - d[:, 1] * f[:, 0]
+        else:
+            V0 = verts[:, i, :]
+            V1 = verts[:, (i + 1) % n_verts, :]
+            e = V1 - V0  # (n, 2)
+            f = V0 - A  # (n, 2)
+            det = d[:, 1] * e[:, 0] - d[:, 0] * e[:, 1]
+            t_num = e[:, 0] * f[:, 1] - e[:, 1] * f[:, 0]
+            s_num = d[:, 0] * f[:, 1] - d[:, 1] * f[:, 0]
+
+        nonzero = np.abs(det) > eps
+        with np.errstate(invalid="ignore", divide="ignore"):
+            t_val = np.where(nonzero, t_num / det, np.nan)
+            s_val = np.where(nonzero, s_num / det, np.nan)
+
+        on_edge = nonzero & (s_val >= 0.0) & (s_val <= 1.0)
+        if "behind" in zones:
+            result |= on_edge & (t_val <= 0.0)
+        if "within" in zones:
+            result |= on_edge & (t_val > 0.0) & (t_val < 1.0)
+        if "front" in zones:
+            result |= on_edge & (t_val >= 1.0)
+
+    return result
+
+
 class Features:
     """
     generates features from a pre-processed Tracking object
@@ -1131,29 +1201,19 @@ class Features:
         df = self.tracking.data
         px = df[point + "." + dims[0]].to_numpy(dtype=float)
         py = df[point + "." + dims[1]].to_numpy(dtype=float)
-        bx = np.column_stack([df[b + "." + dims[0]].to_numpy(dtype=float) for b in boundary_points])
-        by = np.column_stack([df[b + "." + dims[1]].to_numpy(dtype=float) for b in boundary_points])
+        boundary_obj = DynamicBoundary(
+            points=tuple(boundary_points),
+            dims=dims,
+            anchor_points=tuple(anchor_points) if anchor_points is not None else None,
+            scale_dim1=scale_dim1,
+            scale_dim2=scale_dim2,
+        )
+        verts = boundary_obj.to_numpy_per_frame(df)  # (n, N_verts, 2), scaling applied
 
-        if scale_dim1 != 1.0 or scale_dim2 != 1.0:
-            if anchor_points is None:
-                ax = np.nanmean(bx, axis=1)
-                ay = np.nanmean(by, axis=1)
-            else:
-                ax = np.column_stack(
-                    [df[a + "." + dims[0]].to_numpy(dtype=float) for a in anchor_points]
-                )
-                ay = np.column_stack(
-                    [df[a + "." + dims[1]].to_numpy(dtype=float) for a in anchor_points]
-                )
-                ax = np.nanmean(ax, axis=1)
-                ay = np.nanmean(ay, axis=1)
-            bx = ax[:, None] + (bx - ax[:, None]) * scale_dim1
-            by = ay[:, None] + (by - ay[:, None]) * scale_dim2
-
-        valid = ~(np.isnan(px) | np.isnan(py) | np.any(np.isnan(bx) | np.isnan(by), axis=1))
+        valid = ~(np.isnan(px) | np.isnan(py) | np.any(np.isnan(verts), axis=(1, 2)))
         result = pd.Series(pd.array([pd.NA] * len(df), dtype="boolean"), index=df.index)
         if valid.any():
-            coords = np.stack([bx[valid], by[valid]], axis=-1)
+            coords = verts[valid]
             polys = shapely.polygons(shapely.linearrings(coords))
             pts = shapely.points(px[valid], py[valid])
             result[valid] = shapely.contains(polys, pts)
@@ -1387,29 +1447,19 @@ class Features:
         df = self.tracking.data
         px = df[point + "." + dims[0]].to_numpy(dtype=float)
         py = df[point + "." + dims[1]].to_numpy(dtype=float)
-        bx = np.column_stack([df[b + "." + dims[0]].to_numpy(dtype=float) for b in boundary_points])
-        by = np.column_stack([df[b + "." + dims[1]].to_numpy(dtype=float) for b in boundary_points])
+        boundary_obj = DynamicBoundary(
+            points=tuple(boundary_points),
+            dims=dims,
+            anchor_points=tuple(anchor_points) if anchor_points is not None else None,
+            scale_dim1=scale_dim1,
+            scale_dim2=scale_dim2,
+        )
+        verts = boundary_obj.to_numpy_per_frame(df)  # (n, N_verts, 2), scaling applied
 
-        if scale_dim1 != 1.0 or scale_dim2 != 1.0:
-            if anchor_points is None:
-                ax = np.nanmean(bx, axis=1)
-                ay = np.nanmean(by, axis=1)
-            else:
-                ax = np.column_stack(
-                    [df[a + "." + dims[0]].to_numpy(dtype=float) for a in anchor_points]
-                )
-                ay = np.column_stack(
-                    [df[a + "." + dims[1]].to_numpy(dtype=float) for a in anchor_points]
-                )
-                ax = np.nanmean(ax, axis=1)
-                ay = np.nanmean(ay, axis=1)
-            bx = ax[:, None] + (bx - ax[:, None]) * scale_dim1
-            by = ay[:, None] + (by - ay[:, None]) * scale_dim2
-
-        valid = ~(np.isnan(px) | np.isnan(py) | np.any(np.isnan(bx) | np.isnan(by), axis=1))
+        valid = ~(np.isnan(px) | np.isnan(py) | np.any(np.isnan(verts), axis=(1, 2)))
         result = pd.Series(np.nan, index=df.index)
         if valid.any():
-            coords = np.stack([bx[valid], by[valid]], axis=-1)
+            coords = verts[valid]
             polys = shapely.polygons(shapely.linearrings(coords))
             exteriors = shapely.get_exterior_ring(polys)
             pts = shapely.points(px[valid], py[valid])
@@ -1521,8 +1571,10 @@ class Features:
             axis_label = resolved.name
         elif isinstance(resolved, StaticAxis) and resolved.source_points:
             axis_label = "_".join(resolved.source_points)
-        else:
+        elif isinstance(resolved, DynamicAxis):
             axis_label = "_".join(resolved.points)
+        else:
+            axis_label = "axis"
 
         sign_suffix = "_signed" if signed else ""
         name_str = f"distance_to_axis_{point}_from_{axis_label}_in_{''.join(dims)}{sign_suffix}"
@@ -1533,6 +1585,146 @@ class Features:
             "signed": signed,
         }
         return FeaturesResult(series, self, name_str, meta)
+
+    def axis_intersects_boundary(
+        self,
+        axis: str | StaticAxis | DynamicAxis,
+        boundary: str | StaticBoundary | DynamicBoundary,
+        *,
+        dims: tuple[str, str] = ("x", "y"),
+        zones: set[Literal["front", "within", "behind"]] | None = None,
+    ) -> FeaturesResult:
+        """Per-frame boolean: does the axis line cross the boundary polygon?
+
+        The axis is always treated as infinite.  Each intersection point is
+        classified by its scalar projection *t* onto the A→B segment:
+
+        - ``"behind"``: t ≤ 0  (at or before the first reference point)
+        - ``"within"``: 0 < t < 1  (strictly between the two reference points)
+        - ``"front"``:  t ≥ 1  (at or beyond the second reference point)
+
+        A frame is ``True`` when at least one intersection with the boundary
+        falls inside any of the requested ``zones``.  Frames where the axis is
+        degenerate (A == B) or any coordinate is NaN are returned as ``pd.NA``.
+
+        Parameters
+        ----------
+        axis : str, StaticAxis, or DynamicAxis
+            Two-point axis asset, or the name of a registered one.
+        boundary : str, StaticBoundary, or DynamicBoundary
+            Polygon boundary asset, or the name of a registered one.
+        dims : tuple of (str, str), default ``("x", "y")``
+            The 2-D coordinate space for the intersection test.  Both the axis
+            and the boundary must have exactly these dims.
+        zones : set of {"front", "within", "behind"}, optional
+            Which zones count as an intersection.  Defaults to all three (any
+            intersection anywhere along the infinite axis).
+
+        Returns
+        -------
+        FeaturesResult
+            Boolean series (pandas nullable boolean dtype).
+
+        Examples
+        --------
+        ```pycon
+        >>> from py3r.behaviour.util.docdata import data_path
+        >>> from py3r.behaviour.tracking.tracking import Tracking
+        >>> from py3r.behaviour.features.features import Features
+        >>> import pandas as pd
+        >>> with data_path('py3r.behaviour.tracking._data', 'dlc_single.csv') as p:
+        ...     t = Tracking.from_dlc(str(p), handle='ex', fps=30)
+        >>> f = Features(t)
+        >>> ax = f.define_dynamic_axis('p1', 'p2')
+        >>> b = f.define_dynamic_boundary(['p1', 'p2', 'p3'], name='tri')
+        >>> res = f.axis_intersects_boundary(ax, b)
+        >>> bool(isinstance(res, pd.Series))
+        True
+
+        ```
+        """
+        _VALID_ZONES: set[str] = {"front", "within", "behind"}
+        if zones is None:
+            zones = _VALID_ZONES
+        else:
+            unknown = zones - _VALID_ZONES
+            if unknown:
+                raise ValueError(
+                    f"Unknown zone(s): {unknown!r}.  Valid zones are {_VALID_ZONES!r}."
+                )
+            if not zones:
+                raise ValueError("zones must not be empty.")
+
+        resolved_axis = self._resolve_axis_ref(axis)
+        resolved_boundary = self._resolve_boundary_ref(boundary)
+
+        if tuple(resolved_axis.dims) != tuple(dims):
+            raise ValueError(f"axis dims {resolved_axis.dims!r} do not match dims={dims!r}.")
+        if tuple(resolved_boundary.dims) != tuple(dims):
+            raise ValueError(
+                f"boundary dims {resolved_boundary.dims!r} do not match dims={dims!r}."
+            )
+
+        df = self.tracking.data
+        for d in dims:
+            if not any(col.endswith(f".{d}") for col in df.columns):
+                raise ValueError(f"Dimension {d!r} not found in tracking data columns.")
+        n = len(df)
+
+        # Build A and B per frame.
+        if isinstance(resolved_axis, StaticAxis):
+            A = np.tile(np.array(resolved_axis.vertices[0], dtype=float), (n, 1))
+            B = np.tile(np.array(resolved_axis.vertices[1], dtype=float), (n, 1))
+        else:
+            arr = resolved_axis.to_numpy_per_frame(df)  # (n, 2, 2)
+            A = arr[:, 0, :]
+            B = arr[:, 1, :]
+
+        # Build boundary vertices per frame (scaling applied inside to_numpy_per_frame).
+        if isinstance(resolved_boundary, StaticBoundary):
+            verts = np.array(resolved_boundary.vertices, dtype=float)  # (N_verts, 2)
+            boundary_valid = ~np.any(np.isnan(verts))  # scalar; all-or-nothing for static
+            boundary_valid = np.full(n, boundary_valid)
+        else:
+            verts = resolved_boundary.to_numpy_per_frame(df)  # (n, N_verts, 2)
+            boundary_valid = ~np.any(np.isnan(verts), axis=(1, 2))
+
+        axis_nan = np.any(np.isnan(A) | np.isnan(B), axis=1)
+        axis_degenerate = np.linalg.norm(B - A, axis=1) == 0.0
+        valid = ~axis_nan & ~axis_degenerate & boundary_valid
+
+        result = pd.Series(pd.array([pd.NA] * n, dtype="boolean"), index=df.index)
+        if valid.any():
+            v = verts if verts.ndim == 2 else verts[valid]
+            result[valid] = _axis_boundary_intersections(A[valid], B[valid], v, zones)
+
+        if resolved_axis.name:
+            axis_label = resolved_axis.name
+        elif isinstance(resolved_axis, StaticAxis) and resolved_axis.source_points:
+            axis_label = "_".join(resolved_axis.source_points)
+        elif isinstance(resolved_axis, DynamicAxis):
+            axis_label = "_".join(resolved_axis.points)
+        else:
+            axis_label = "axis"
+
+        boundary_label = resolved_boundary.name or self._short_boundary_id(
+            list(
+                resolved_boundary.vertices
+                if isinstance(resolved_boundary, StaticBoundary)
+                else resolved_boundary.points
+            )
+        )
+
+        zones_str = "_".join(sorted(zones))
+        name_str = f"axis_intersects_boundary_{axis_label}_{boundary_label}_{zones_str}"
+        meta = {
+            "function": "axis_intersects_boundary",
+            "axis": resolved_axis.to_dict(),
+            "boundary": resolved_boundary.to_dict(),
+            "dims": list(dims),
+            "zones": sorted(zones),
+        }
+        return FeaturesResult(result, self, name_str, meta)
 
     def area_of_boundary(
         self, boundary: str | StaticBoundary | DynamicBoundary, **kwargs
@@ -1590,35 +1782,9 @@ class Features:
             name = f"area_of_boundary_{boundary_label}_dynamic"
             meta = {"function": "area_of_boundary", "boundary": boundary.to_dict()}
             df = self.tracking.data
-            bx = np.column_stack(
-                [df[b + "." + boundary.dims[0]].to_numpy(dtype=float) for b in boundary.points]
-            )
-            by = np.column_stack(
-                [df[b + "." + boundary.dims[1]].to_numpy(dtype=float) for b in boundary.points]
-            )
-
-            if boundary.scale_dim1 != 1.0 or boundary.scale_dim2 != 1.0:
-                if boundary.anchor_points is None:
-                    ax = np.nanmean(bx, axis=1)
-                    ay = np.nanmean(by, axis=1)
-                else:
-                    ax = np.column_stack(
-                        [
-                            df[a + "." + boundary.dims[0]].to_numpy(dtype=float)
-                            for a in boundary.anchor_points
-                        ]
-                    )
-                    ay = np.column_stack(
-                        [
-                            df[a + "." + boundary.dims[1]].to_numpy(dtype=float)
-                            for a in boundary.anchor_points
-                        ]
-                    )
-                    ax = np.nanmean(ax, axis=1)
-                    ay = np.nanmean(ay, axis=1)
-                bx = ax[:, None] + (bx - ax[:, None]) * boundary.scale_dim1
-                by = ay[:, None] + (by - ay[:, None]) * boundary.scale_dim2
-
+            verts = boundary.to_numpy_per_frame(df)  # (n, N_verts, 2), scaling applied
+            bx = verts[:, :, 0]
+            by = verts[:, :, 1]
             bx_next = np.roll(bx, -1, axis=1)
             by_next = np.roll(by, -1, axis=1)
             result = pd.Series(

--- a/src/py3r/behaviour/features/features.py
+++ b/src/py3r/behaviour/features/features.py
@@ -1592,7 +1592,9 @@ class Features:
         boundary: str | StaticBoundary | DynamicBoundary,
         *,
         dims: tuple[str, str] = ("x", "y"),
-        zones: set[Literal["front", "within", "behind"]] | None = None,
+        zones: Literal["front", "within", "behind"]
+        | set[Literal["front", "within", "behind"]]
+        | None = None,
     ) -> FeaturesResult:
         """Per-frame boolean: does the axis line cross the boundary polygon?
 
@@ -1616,8 +1618,9 @@ class Features:
         dims : tuple of (str, str), default ``("x", "y")``
             The 2-D coordinate space for the intersection test.  Both the axis
             and the boundary must have exactly these dims.
-        zones : set of {"front", "within", "behind"}, optional
-            Which zones count as an intersection.  Defaults to all three (any
+        zones : {"front", "within", "behind"} or set thereof, optional
+            Which zones count as an intersection.  A single zone name (e.g.
+            ``"front"``) or a set of names.  Defaults to all three (any
             intersection anywhere along the infinite axis).
 
         Returns
@@ -1644,6 +1647,8 @@ class Features:
         ```
         """
         _VALID_ZONES: set[str] = {"front", "within", "behind"}
+        if isinstance(zones, str):
+            zones = {zones}
         if zones is None:
             zones = _VALID_ZONES
         else:

--- a/src/py3r/behaviour/util/dataframe_utils.py
+++ b/src/py3r/behaviour/util/dataframe_utils.py
@@ -207,8 +207,8 @@ def point_to_axis_distance(
 
     Notes
     -----
-    Degenerate frames where A == B (zero-length direction) return the distance
-    from P to A (unsigned) or zero (signed) without raising an error.
+    Degenerate frames where A == B (zero-length direction) return ``nan``
+    for both the signed and unsigned cases, as the axis direction is undefined.
 
     Examples
     --------
@@ -237,16 +237,16 @@ def point_to_axis_distance(
         # of the unit direction d = AB / |AB|.
         # perp_right = (d[1], -d[0])  →  AP · perp_right / |AB| * |AB| simplifies to:
         #   (AP[0] * AB[1] - AP[1] * AB[0]) / |AB|
-        # Degenerate frames (A == B) → signed distance = 0.
+        # Degenerate frames (A == B) → axis undefined, return NaN.
         ab_norm = np.sqrt(ab_sq)
         with np.errstate(invalid="ignore", divide="ignore"):
             cross = AP[:, 0] * AB[:, 1] - AP[:, 1] * AB[:, 0]
-            return np.where(ab_norm > 0, cross / ab_norm, 0.0)
+            return np.where(ab_norm > 0, cross / ab_norm, np.nan)
 
     # Scalar projection of P onto the infinite axis through A and B.
-    # Degenerate frames (A == B) get t = 0, i.e. closest point = A.
+    # Degenerate frames (A == B) → axis undefined, return NaN.
     with np.errstate(invalid="ignore", divide="ignore"):
-        t = np.where(ab_sq > 0, np.sum(AP * AB, axis=1) / ab_sq, 0.0)
+        t = np.where(ab_sq > 0, np.sum(AP * AB, axis=1) / ab_sq, np.nan)
 
     closest = A + t[:, np.newaxis] * AB  # (n, d)
     return np.linalg.norm(P - closest, axis=1)  # (n,)

--- a/tests/test_features_axis_intersects_boundary.py
+++ b/tests/test_features_axis_intersects_boundary.py
@@ -1,0 +1,305 @@
+"""Tests for Features.axis_intersects_boundary.
+
+Geometry
+--------
+All frames share a horizontal axis  A=(0,0) → B=(10,0)  (except frames that
+test degenerate/NaN behaviour).  Zone classification by scalar projection t:
+
+    behind : t ≤ 0   (at or before A)
+    within : 0 < t < 1  (strictly between A and B)
+    front  : t ≥ 1   (at or beyond B)
+
+Frame layout
+------------
+0 : both crossings within (t≈0.37, t≈0.63)   → within=T, behind=F, front=F
+1 : both crossings behind (t≈−0.37, t≈−0.63) → within=F, behind=T, front=F
+2 : both crossings front  (t≈1.37, t≈1.63)   → within=F, behind=F, front=T
+3 : one behind (t=−0.1),  one within (t=0.3)  → within=T, behind=T, front=F
+4 : one within (t=0.7),   one front (t=1.1)   → within=T, behind=F, front=T
+5 : no crossing (triangle entirely above y=0)  → all False
+6 : degenerate axis A==B                       → all <NA>
+7 : NaN in axis reference point                → all <NA>
+8 : crossing exactly at A (t=0, t=0.1)         → behind=T, within=T, front=F
+9 : crossing exactly at B (t=1.0, t=1.1)       → within=F, behind=F, front=T
+"""
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from py3r.behaviour.features.features import Features
+from py3r.behaviour.tracking.tracking import Tracking
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_tracking():
+    data = pd.DataFrame(
+        {
+            # Axis reference points
+            "a.x": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 5.0, np.nan, 0.0, 0.0],
+            "a.y": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            "b.x": [10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 5.0, 10.0, 10.0, 10.0],
+            "b.y": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            # Boundary triangle vertices
+            #   p1: first vertex (below axis in frames 0-4, above in frame 5)
+            "p1.x": [3.0, -3.0, 13.0, -2.0, 6.0, 3.0, 3.0, 3.0, -1.0, 9.0],
+            "p1.y": [-2.0, -2.0, -2.0, -2.0, -2.0, 2.0, -2.0, -2.0, -1.0, -1.0],
+            "p2.x": [7.0, -7.0, 17.0, 4.0, 12.0, 7.0, 7.0, 7.0, 1.0, 11.0],
+            "p2.y": [-2.0, -2.0, -2.0, -2.0, -2.0, 2.0, -2.0, -2.0, 1.0, 1.0],
+            "p3.x": [5.0, -5.0, 15.0, 1.0, 9.0, 5.0, 5.0, 5.0, 1.0, 11.0],
+            "p3.y": [4.0, 4.0, 4.0, 4.0, 4.0, 6.0, 4.0, 4.0, -1.0, -1.0],
+        },
+        index=pd.RangeIndex(10, name="frame"),
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return Tracking(data, {"fps": 30.0}, handle="test")
+
+
+@pytest.fixture
+def f():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return Features(_make_tracking())
+
+
+@pytest.fixture
+def dyn_axis(f):
+    return f.define_dynamic_axis("a", "b", dims=("x", "y"))
+
+
+@pytest.fixture
+def dyn_boundary(f):
+    return f.define_dynamic_boundary(["p1", "p2", "p3"], dims=("x", "y"), name="tri")
+
+
+def _call(f, *args, **kwargs):
+    """Call axis_intersects_boundary suppressing calibration/smoothing warnings."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return f.axis_intersects_boundary(*args, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Core zone classification
+# ---------------------------------------------------------------------------
+
+
+class TestZoneClassification:
+    def test_within_true_both_crossings_in_segment(self, f, dyn_axis, dyn_boundary):
+        res = _call(f, dyn_axis, dyn_boundary, zones={"within"})
+        assert res.iloc[0]
+
+    def test_within_false_all_crossings_behind(self, f, dyn_axis, dyn_boundary):
+        res = _call(f, dyn_axis, dyn_boundary, zones={"within"})
+        assert not res.iloc[1]
+
+    def test_within_false_all_crossings_front(self, f, dyn_axis, dyn_boundary):
+        res = _call(f, dyn_axis, dyn_boundary, zones={"within"})
+        assert not res.iloc[2]
+
+    def test_behind_true_crossings_before_A(self, f, dyn_axis, dyn_boundary):
+        res = _call(f, dyn_axis, dyn_boundary, zones={"behind"})
+        assert res.iloc[1]
+
+    def test_behind_false_crossings_front(self, f, dyn_axis, dyn_boundary):
+        res = _call(f, dyn_axis, dyn_boundary, zones={"behind"})
+        assert not res.iloc[2]
+
+    def test_front_true_crossings_beyond_B(self, f, dyn_axis, dyn_boundary):
+        res = _call(f, dyn_axis, dyn_boundary, zones={"front"})
+        assert res.iloc[2]
+
+    def test_front_false_crossings_within(self, f, dyn_axis, dyn_boundary):
+        res = _call(f, dyn_axis, dyn_boundary, zones={"front"})
+        assert not res.iloc[0]
+
+    def test_mixed_behind_and_within(self, f, dyn_axis, dyn_boundary):
+        # frame 3: t=-0.1 (behind) and t=0.3 (within)
+        assert _call(f, dyn_axis, dyn_boundary, zones={"behind"}).iloc[3]
+        assert _call(f, dyn_axis, dyn_boundary, zones={"within"}).iloc[3]
+        assert not _call(f, dyn_axis, dyn_boundary, zones={"front"}).iloc[3]
+
+    def test_mixed_within_and_front(self, f, dyn_axis, dyn_boundary):
+        # frame 4: t=0.7 (within) and t=1.1 (front)
+        assert not _call(f, dyn_axis, dyn_boundary, zones={"behind"}).iloc[4]
+        assert _call(f, dyn_axis, dyn_boundary, zones={"within"}).iloc[4]
+        assert _call(f, dyn_axis, dyn_boundary, zones={"front"}).iloc[4]
+
+    def test_false_when_no_crossing(self, f, dyn_axis, dyn_boundary):
+        # frame 5: triangle entirely above y=0
+        res = _call(f, dyn_axis, dyn_boundary)
+        assert not res.iloc[5]
+
+    def test_default_zones_equals_all_three_explicit(self, f, dyn_axis, dyn_boundary):
+        default = _call(f, dyn_axis, dyn_boundary)
+        explicit = _call(f, dyn_axis, dyn_boundary, zones={"front", "within", "behind"})
+        pd.testing.assert_series_equal(pd.Series(default), pd.Series(explicit))
+
+
+# ---------------------------------------------------------------------------
+# Zone boundary cases: t=0 is "behind", t=1 is "front"
+# ---------------------------------------------------------------------------
+
+
+class TestZoneBoundaries:
+    def test_t_zero_classified_as_behind_not_within(self, f, dyn_axis, dyn_boundary):
+        # frame 8: edge crosses axis exactly at A → t=0 → behind
+        assert _call(f, dyn_axis, dyn_boundary, zones={"behind"}).iloc[8]
+        # second crossing at t=0.1 makes within also True for this frame
+        assert _call(f, dyn_axis, dyn_boundary, zones={"within"}).iloc[8]
+        assert not _call(f, dyn_axis, dyn_boundary, zones={"front"}).iloc[8]
+
+    def test_t_one_classified_as_front_not_within(self, f, dyn_axis, dyn_boundary):
+        # frame 9: edge crosses axis exactly at B → t=1 → front; second crossing at t=1.1 also front
+        assert _call(f, dyn_axis, dyn_boundary, zones={"front"}).iloc[9]
+        assert not _call(f, dyn_axis, dyn_boundary, zones={"within"}).iloc[9]
+        assert not _call(f, dyn_axis, dyn_boundary, zones={"behind"}).iloc[9]
+
+
+# ---------------------------------------------------------------------------
+# NaN and degenerate axis handling
+# ---------------------------------------------------------------------------
+
+
+class TestNaNAndDegenerate:
+    def test_degenerate_axis_gives_na(self, f, dyn_axis, dyn_boundary):
+        # frame 6: A == B
+        res = _call(f, dyn_axis, dyn_boundary)
+        assert pd.isna(res.iloc[6])
+
+    def test_nan_axis_gives_na(self, f, dyn_axis, dyn_boundary):
+        # frame 7: a.x is NaN
+        res = _call(f, dyn_axis, dyn_boundary)
+        assert pd.isna(res.iloc[7])
+
+    def test_result_dtype_is_nullable_boolean(self, f, dyn_axis, dyn_boundary):
+        res = _call(f, dyn_axis, dyn_boundary)
+        assert isinstance(res.dtype, pd.BooleanDtype)
+
+    def test_valid_frames_are_not_na(self, f, dyn_axis, dyn_boundary):
+        res = _call(f, dyn_axis, dyn_boundary)
+        for i in range(6):
+            assert not pd.isna(res.iloc[i]), f"frame {i} unexpectedly NA"
+
+
+# ---------------------------------------------------------------------------
+# Static axis and static boundary variants
+# ---------------------------------------------------------------------------
+
+
+class TestStaticVariants:
+    def test_static_axis_matches_dynamic_on_valid_frames(self, f, dyn_boundary):
+        static_ax = f.import_static_axis([(0.0, 0.0), (10.0, 0.0)], dims=("x", "y"))
+        dyn_ax = f.define_dynamic_axis("a", "b", dims=("x", "y"))
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            s = f.axis_intersects_boundary(static_ax, dyn_boundary, zones={"within"})
+            d = f.axis_intersects_boundary(dyn_ax, dyn_boundary, zones={"within"})
+        # Static axis is always valid, so frames 6 and 7 differ (dyn gives NA).
+        for i in range(6):
+            assert s.iloc[i] == d.iloc[i], f"frame {i} differs between static and dynamic axis"
+
+    def test_static_boundary_all_frames_same_result(self, f, dyn_axis):
+        # Triangle (3,-2),(7,-2),(5,4) crosses within on every frame where axis is valid.
+        static_b = f.import_static_boundary([(3.0, -2.0), (7.0, -2.0), (5.0, 4.0)], dims=("x", "y"))
+        res = _call(f, dyn_axis, static_b, zones={"within"})
+        for i in range(6):
+            assert res.iloc[i], f"frame {i}: expected True"
+        assert pd.isna(res.iloc[6])  # degenerate axis
+        assert pd.isna(res.iloc[7])  # NaN axis
+
+    def test_accepts_axis_by_registered_name(self, f, dyn_boundary):
+        f.define_dynamic_axis("a", "b", dims=("x", "y"), name="spine")
+        res = _call(f, "spine", dyn_boundary, zones={"within"})
+        assert res.iloc[0]
+
+    def test_accepts_boundary_by_registered_name(self, f, dyn_axis, dyn_boundary):
+        res = _call(f, dyn_axis, "tri", zones={"within"})
+        assert res.iloc[0]
+
+
+# ---------------------------------------------------------------------------
+# Validation and error cases
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_unknown_zone_raises(self, f, dyn_axis, dyn_boundary):
+        with pytest.raises(ValueError, match="Unknown zone"):
+            _call(f, dyn_axis, dyn_boundary, zones={"sideways"})
+
+    def test_empty_zones_raises(self, f, dyn_axis, dyn_boundary):
+        with pytest.raises(ValueError, match="must not be empty"):
+            _call(f, dyn_axis, dyn_boundary, zones=set())
+
+    def test_dims_mismatch_on_axis_raises(self, f, dyn_boundary):
+        # Static axis with dims=("x","z"), calling with dims=("x","y")
+        ax_xz = f.import_static_axis([(0.0, 0.0), (10.0, 0.0)], dims=("x", "z"))
+        with pytest.raises(ValueError, match="axis dims"):
+            _call(f, ax_xz, dyn_boundary, dims=("x", "y"))
+
+    def test_dims_mismatch_on_boundary_raises(self, f):
+        # Static axis with dims=("x","z"), static boundary with dims=("x","y"),
+        # calling with dims=("x","z") → boundary dims mismatch
+        ax_xz = f.import_static_axis([(0.0, 0.0), (10.0, 0.0)], dims=("x", "z"))
+        b_xy = f.import_static_boundary([(3.0, -2.0), (7.0, -2.0), (5.0, 4.0)], dims=("x", "y"))
+        with pytest.raises(ValueError, match="boundary dims"):
+            _call(f, ax_xz, b_xy, dims=("x", "z"))
+
+    def test_passing_boundary_as_axis_raises(self, f, dyn_boundary):
+        with pytest.raises(TypeError):
+            _call(f, dyn_boundary, dyn_boundary)
+
+    def test_passing_axis_as_boundary_raises(self, f, dyn_axis):
+        with pytest.raises(TypeError):
+            _call(f, dyn_axis, dyn_axis)
+
+
+# ---------------------------------------------------------------------------
+# Feature name and meta
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureNameAndMeta:
+    def test_name_contains_function(self, f, dyn_axis, dyn_boundary):
+        res = _call(f, dyn_axis, dyn_boundary, zones={"within"})
+        assert "axis_intersects_boundary" in res.name
+
+    def test_name_contains_named_axis_label(self, f, dyn_boundary):
+        f.define_dynamic_axis("a", "b", dims=("x", "y"), name="spine")
+        res = _call(f, "spine", dyn_boundary, zones={"within"})
+        assert "spine" in res.name
+
+    def test_name_contains_named_boundary_label(self, f, dyn_axis, dyn_boundary):
+        res = _call(f, dyn_axis, "tri", zones={"within"})
+        assert "tri" in res.name
+
+    def test_name_contains_zone(self, f, dyn_axis, dyn_boundary):
+        res = _call(f, dyn_axis, dyn_boundary, zones={"within"})
+        assert "within" in res.name
+
+    def test_name_zones_are_sorted(self, f, dyn_axis, dyn_boundary):
+        res = _call(f, dyn_axis, dyn_boundary, zones={"front", "behind"})
+        assert "behind_front" in res.name
+
+    def test_meta_function_key(self, f, dyn_axis, dyn_boundary):
+        res = _call(f, dyn_axis, dyn_boundary)
+        assert res._params["function"] == "axis_intersects_boundary"
+
+    def test_meta_zones_are_sorted(self, f, dyn_axis, dyn_boundary):
+        res = _call(f, dyn_axis, dyn_boundary, zones={"front", "within"})
+        assert res._params["zones"] == sorted(["front", "within"])
+
+    def test_meta_dims(self, f, dyn_axis, dyn_boundary):
+        res = _call(f, dyn_axis, dyn_boundary)
+        assert res._params["dims"] == ["x", "y"]
+
+    def test_result_length_matches_tracking(self, f, dyn_axis, dyn_boundary):
+        res = _call(f, dyn_axis, dyn_boundary)
+        assert len(res) == len(f.tracking.data)

--- a/tests/test_features_axis_intersects_boundary.py
+++ b/tests/test_features_axis_intersects_boundary.py
@@ -230,6 +230,11 @@ class TestStaticVariants:
 
 
 class TestValidation:
+    def test_zones_string_shorthand_matches_set(self, f, dyn_axis, dyn_boundary):
+        str_result = _call(f, dyn_axis, dyn_boundary, zones="within")
+        set_result = _call(f, dyn_axis, dyn_boundary, zones={"within"})
+        pd.testing.assert_series_equal(pd.Series(str_result), pd.Series(set_result))
+
     def test_unknown_zone_raises(self, f, dyn_axis, dyn_boundary):
         with pytest.raises(ValueError, match="Unknown zone"):
             _call(f, dyn_axis, dyn_boundary, zones={"sideways"})


### PR DESCRIPTION
### Summary
<!-- 
A short description of what this PR does.

Example:
- Adds aggregation functions for multi-animal keypoint trajectories.
-->
- centralise `DynamicBoundary` scaling: moved `scale_dim1`/`scale_dim2`/`anchor_points`
  logic into `DynamicBoundary.to_numpy_per_frame`; removed three copies of the same block
  from `_within_boundary_dynamic_impl`, `_distance_to_boundary_dynamic_impl`, and
  `area_of_boundary` (also fixes a latent bug where boundary animation omitted
  scaling for dynamic boundaries).
- fix degenerate axis returns: `point_to_axis_distance` now returns `nan` (instead of
  `0.0`) for frames where A == B, as the axis direction is undefined in those frames.
- fix axis label `AttributeError`: `distance_to_axis` and `axis_intersects_boundary`
  both had an `else` fallback that called `.points` on a `StaticAxis` (which has no such
  attribute); replaced with an explicit `isinstance(…, DynamicAxis)` branch and an `"axis"`
  fallback.
- `axis_intersects_boundary`: per-frame boolean indicating whether an
  axis line crosses a polygon boundary, with a `zones` parameter to restrict hits to
  `"behind"` (t ≤ 0), `"within"` (0 < t < 1), or `"front"` (t ≥ 1) relative to the A→B
  reference segment; accepts static and dynamic axis/boundary assets; degenerate/NaN frames
  return `pd.NA`.
- `test_features_axis_intersects_boundary.py` covering zone
  classification, t=0/t=1 boundary cases, NaN/degenerate handling, static variants, name
  lookup by string, validation errors, and feature name/meta correctness.

### Type of change
<!-- 
At least one MUST be checked.
Use lowercase x exactly like this: [x]
-->
- [x] ✨ Feature
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 🧹 Chore / Refactor
- [ ] 📚 Docs

### User-facing change
<!-- 
This is what will appear in the release notes.
Write as a single bullet starting with - 

Example:
- Fixed incorrect body-angle computation when animals rotate >180°.
-->
- new `axis_intersects_boundary` feature

### Testing
<!-- 
Explain how you tested the change.

Example:
- Added docstring tests covering interpolation of missing keypoints.
-->
- bespoke tests
