### PR TITLE
Feature/collate bin summary dfs

### DIFF
--- a/src/py3r/behaviour/summary/summary.py
+++ b/src/py3r/behaviour/summary/summary.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import warnings
 from copy import deepcopy
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
@@ -1174,7 +1175,7 @@ class Summary:
             if save_dir:
                 os.makedirs(save_dir, exist_ok=True)
                 fig.savefig(
-                    os.path.join(save_dir, f"{self.handle}_chord_{column}.png"),
+                    os.path.join(save_dir, f"{Path(self.handle).name}_chord_{column}.png"),
                     dpi=300,
                     bbox_inches="tight",
                     pad_inches=0.02,
@@ -1234,7 +1235,7 @@ class Summary:
             if save_dir:
                 os.makedirs(save_dir, exist_ok=True)
                 fig.savefig(
-                    os.path.join(save_dir, f"{self.handle}_chord_{column}.png"),
+                    os.path.join(save_dir, f"{Path(self.handle).name}_chord_{column}.png"),
                     dpi=300,
                     bbox_inches="tight",
                     pad_inches=0.02,
@@ -1258,7 +1259,7 @@ class Summary:
             if save_dir:
                 os.makedirs(save_dir, exist_ok=True)
                 fig.savefig(
-                    os.path.join(save_dir, f"{self.handle}_chord_{column}.png"),
+                    os.path.join(save_dir, f"{Path(self.handle).name}_chord_{column}.png"),
                     dpi=300,
                     bbox_inches="tight",
                     pad_inches=0.02,

--- a/src/py3r/behaviour/summary/summary_collection.py
+++ b/src/py3r/behaviour/summary/summary_collection.py
@@ -249,6 +249,101 @@ class SummaryCollection(BaseCollection, SummaryCollectionPlotMixin):
             series_tables[metric_name] = table
         return scalars_df, series_tables
 
+    @staticmethod
+    def collate_bin_dfs(
+        dfs: list[pd.DataFrame] | dict[str, pd.DataFrame],
+        format: Literal["tall", "wide"] = "tall",
+        bin_col: str = "bin",
+    ) -> pd.DataFrame:
+        """
+        Collate a sequence of per-bin DataFrames into a single table.
+
+        Intended for DataFrames produced by :meth:`to_df`, one per time bin
+        (e.g. from :meth:`make_bins`).
+
+        Args:
+            dfs: List of DataFrames (bins labeled ``0, 1, 2, ...``) or a dict
+                mapping bin labels to DataFrames. Each DataFrame must be indexed
+                by handle.
+            format: ``'tall'`` stacks rows and adds a bin column;
+                ``'wide'`` produces one row per handle with columns named
+                ``<metric>_<bin_label>``.
+            bin_col: Name of the bin column inserted in tall format.
+
+        Returns:
+            Collated DataFrame.
+
+            Tall: index is handle. Rows are ordered so that all bins for a given
+            handle appear together (handle-major), with bins in the order supplied.
+            Wide: index is handle. Columns are ordered metric-major — all bins for
+            a given metric appear together (``metric_bin0``, ``metric_bin1``, ...),
+            then the next metric, and so on. Metric order follows the first
+            DataFrame supplied.
+
+        Examples
+        --------
+        ```pycon
+        >>> import pandas as pd
+        >>> from py3r.behaviour.util.docdata import data_path
+        >>> from py3r.behaviour.tracking.tracking import Tracking
+        >>> from py3r.behaviour.features.features import Features
+        >>> from py3r.behaviour.summary.summary import Summary
+        >>> from py3r.behaviour.summary.summary_collection import SummaryCollection
+        >>> with data_path('py3r.behaviour.tracking._data', 'dlc_single.csv') as p:
+        ...     t1 = Tracking.from_dlc(str(p), handle='A', fps=30)
+        ...     t2 = Tracking.from_dlc(str(p), handle='B', fps=30)
+        >>> s1, s2 = Summary(Features(t1)), Summary(Features(t2))
+        >>> s1.store(1.0, 'score'); s2.store(2.0, 'score')
+        >>> sc = SummaryCollection.from_list([s1, s2])
+        >>> df0 = sc.to_df(); df0['score'] = [1.0, 2.0]
+        >>> df1 = sc.to_df(); df1['score'] = [1.5, 2.5]
+        >>> tall = SummaryCollection.collate_bin_dfs([df0, df1], format='tall')
+        >>> list(tall.columns[:2])
+        ['bin', 'score']
+        >>> list(tall.index)
+        ['A', 'A', 'B', 'B']
+        >>> wide = SummaryCollection.collate_bin_dfs({'early': df0, 'late': df1}, format='wide')
+        >>> list(wide.columns)
+        ['score_early', 'score_late']
+
+        ```
+        """
+        if format not in {"tall", "wide"}:
+            raise ValueError("format must be 'tall' or 'wide'")
+
+        labeled: dict = dict(enumerate(dfs)) if isinstance(dfs, list) else dict(dfs)
+        if not labeled:
+            return pd.DataFrame()
+
+        if format == "tall":
+            parts = []
+            for label, df in labeled.items():
+                part = df.copy()
+                part.insert(0, bin_col, label)
+                parts.append(part)
+            result = pd.concat(parts, axis=0)
+            # sort handle-major, preserving bin insertion order within each handle
+            bin_order = {label: i for i, label in enumerate(labeled)}
+            result = result.iloc[result[bin_col].map(bin_order).argsort(kind="stable")]
+            result = result.iloc[result.index.argsort(kind="stable")]
+            result.index.name = "handle"
+            return result
+
+        # wide: build (metric, bin) MultiIndex, sort metric-major, then flatten
+        parts = []
+        for label, df in labeled.items():
+            part = df.copy()
+            part.columns = pd.MultiIndex.from_tuples([(col, label) for col in df.columns])
+            parts.append(part)
+        result_mi = pd.concat(parts, axis=1)
+        metrics = list(dict.fromkeys(m for m, _ in result_mi.columns))
+        bins = list(labeled.keys())
+        ordered = [(m, b) for m in metrics for b in bins if (m, b) in result_mi.columns]
+        result_mi = result_mi[ordered]
+        result_mi.columns = [f"{m}_{b}" for m, b in result_mi.columns]
+        result_mi.index.name = "handle"
+        return result_mi
+
     def make_bin(self, startframe: int, endframe: int):
         """
         Return a new SummaryCollection restricted to frames in [startframe, endframe).

--- a/src/py3r/behaviour/tracking/tracking.py
+++ b/src/py3r/behaviour/tracking/tracking.py
@@ -1891,7 +1891,7 @@ class Tracking:
             import os
 
             os.makedirs(savedir, exist_ok=True)
-            out_path = os.path.join(savedir, f"{self.handle}_plot.png")
+            out_path = os.path.join(savedir, f"{Path(self.handle).name}_plot.png")
             fig.savefig(out_path, dpi=300, bbox_inches="tight", pad_inches=0.02)
         if show:
             plt.show()

--- a/src/py3r/behaviour/tracking/tracking_collection.py
+++ b/src/py3r/behaviour/tracking/tracking_collection.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+from collections import Counter
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -16,6 +17,53 @@ from py3r.behaviour.util.dev_utils import dev_mode
 
 if TYPE_CHECKING:
     from py3r.behaviour.features.features_collection import FeaturesCollection
+
+
+def _disambiguate_stems(paths: list) -> list[str]:
+    """
+    Build short, unique labels for a list of file paths.
+
+    Each label starts as the file's stem (filename without extension). If two or
+    more paths share a stem, the colliding labels are prefixed with their parent
+    directory name, repeating with grandparent etc. until unique. Labels that are
+    not involved in a collision stay as plain stems.
+
+    If two paths are still indistinguishable after exhausting all parent
+    directories (e.g. duplicate paths), a numeric suffix is appended.
+    """
+    resolved = [Path(p).resolve() for p in paths]
+    # parts[i]: [stem, parent_dir_name, grandparent_dir_name, ...]
+    parts = [[rp.stem, *reversed(rp.parent.parts)] for rp in resolved]
+    depth = [1] * len(paths)
+
+    while True:
+        labels = ["_".join(reversed(parts[i][: depth[i]])) for i in range(len(paths))]
+        counts = Counter(labels)
+        dupes = [i for i, label in enumerate(labels) if counts[label] > 1]
+        if not dupes:
+            break
+        progressed = False
+        for i in dupes:
+            if depth[i] < len(parts[i]):
+                depth[i] += 1
+                progressed = True
+        if not progressed:
+            break
+
+    labels = ["_".join(reversed(parts[i][: depth[i]])) for i in range(len(paths))]
+    counts = Counter(labels)
+    seen: dict[str, int] = {}
+    result = []
+    for i, label in enumerate(labels):
+        if counts[label] > 1:
+            # Exhausted all parent directories and still colliding (e.g. duplicate
+            # paths): fall back to a plain stem with a numeric suffix.
+            stem = parts[i][0]
+            seen[stem] = seen.get(stem, 0) + 1
+            result.append(f"{stem}_{seen[stem]}")
+        else:
+            result.append(label)
+    return result
 
 
 class TrackingCollection(BaseCollection):
@@ -272,6 +320,29 @@ class TrackingCollection(BaseCollection):
         ['control', 'treated']
 
         ```
+
+        Handles default to the file stem (e.g. ``mouse1``, ``mouse2`` above) plus
+        the group name. If two files in the same group share a stem, parent
+        directory names are prepended (only as far as needed) to keep handles
+        unique:
+
+        ```pycon
+        >>> import tempfile, shutil
+        >>> from pathlib import Path
+        >>> from py3r.behaviour.util.docdata import data_path
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     d = Path(d)
+        ...     with data_path('py3r.behaviour.tracking._data', 'yolo3r.csv') as p:
+        ...         cohort_a = d / 'cohortA'; cohort_b = d / 'cohortB'
+        ...         cohort_a.mkdir(); cohort_b.mkdir()
+        ...         a = cohort_a / '1.csv'; b = cohort_b / '1.csv'
+        ...         _ = shutil.copy(p, a); _ = shutil.copy(p, b)
+        ...     groups = {'control': [a, b]}
+        ...     tc = TrackingCollection.from_groups(groups, fps=30)
+        >>> sorted(tc.keys())
+        ['cohortA_1_control', 'cohortB_1_control']
+
+        ```
         """
         _SUPPORTED_FMTS = {"yolo3r"}
         if fmt not in _SUPPORTED_FMTS:
@@ -300,7 +371,10 @@ class TrackingCollection(BaseCollection):
         per_group: list[TrackingCollection] = []
         for group_name, paths in groups.items():
             safe = safe_names[group_name]
-            handles_and_paths = {f"{Path(p).resolve()}_{safe}": str(p) for p in paths}
+            stems = _disambiguate_stems(paths)
+            handles_and_paths = {
+                f"{stem}_{safe}": str(p) for stem, p in zip(stems, paths, strict=True)
+            }
             if fmt == "yolo3r":
                 tc = cls.from_yolo3r(handles_and_paths, fps=fps)
             if strip_columns:

--- a/src/py3r/behaviour/tracking/tracking_collection.py
+++ b/src/py3r/behaviour/tracking/tracking_collection.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import re
 from collections.abc import Callable
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 import pandas as pd
@@ -282,16 +283,24 @@ class TrackingCollection(BaseCollection):
             sanitized = re.sub(r"[^A-Za-z0-9]+", "_", name).strip("_")
             return sanitized or "group"
 
-        per_group: list[TrackingCollection] = []
+        # validate empty groups and build safe group-name labels up front
+        safe_names: dict[str, str] = {}
         for group_name, paths in groups.items():
             if not paths:
                 raise ValueError(f"Group {group_name!r} has an empty path list.")
             safe = _sanitize(group_name)
+            if safe in safe_names.values():
+                colliding = [g for g, s in safe_names.items() if s == safe]
+                raise ValueError(
+                    f"Group names {colliding + [group_name]} all sanitize to {safe!r}. "
+                    "Rename the groups to avoid ambiguity."
+                )
+            safe_names[group_name] = safe
 
-            def _stem(p) -> str:
-                return p.stem if hasattr(p, "stem") else os.path.splitext(os.path.basename(p))[0]
-
-            handles_and_paths = {f"{_stem(p)}_{safe}": str(p) for p in sorted(paths)}
+        per_group: list[TrackingCollection] = []
+        for group_name, paths in groups.items():
+            safe = safe_names[group_name]
+            handles_and_paths = {f"{Path(p).resolve()}_{safe}": str(p) for p in paths}
             if fmt == "yolo3r":
                 tc = cls.from_yolo3r(handles_and_paths, fps=fps)
             if strip_columns:

--- a/src/py3r/behaviour/tracking/tracking_collection.py
+++ b/src/py3r/behaviour/tracking/tracking_collection.py
@@ -29,7 +29,8 @@ def _disambiguate_stems(paths: list) -> list[str]:
     not involved in a collision stay as plain stems.
 
     If two paths are still indistinguishable after exhausting all parent
-    directories (e.g. duplicate paths), a numeric suffix is appended.
+    directories (i.e. they are the same path), the returned labels remain
+    duplicates -- callers needing uniqueness must disambiguate further.
     """
     resolved = [Path(p).resolve() for p in paths]
     # parts[i]: [stem, parent_dir_name, grandparent_dir_name, ...]
@@ -47,23 +48,14 @@ def _disambiguate_stems(paths: list) -> list[str]:
             if depth[i] < len(parts[i]):
                 depth[i] += 1
                 progressed = True
+            else:
+                # Exhausted all parent directories (i.e. duplicate paths): fall
+                # back to the plain stem rather than an unreadable full path.
+                depth[i] = 1
         if not progressed:
             break
 
-    labels = ["_".join(reversed(parts[i][: depth[i]])) for i in range(len(paths))]
-    counts = Counter(labels)
-    seen: dict[str, int] = {}
-    result = []
-    for i, label in enumerate(labels):
-        if counts[label] > 1:
-            # Exhausted all parent directories and still colliding (e.g. duplicate
-            # paths): fall back to a plain stem with a numeric suffix.
-            stem = parts[i][0]
-            seen[stem] = seen.get(stem, 0) + 1
-            result.append(f"{stem}_{seen[stem]}")
-        else:
-            result.append(label)
-    return result
+    return ["_".join(reversed(parts[i][: depth[i]])) for i in range(len(paths))]
 
 
 class TrackingCollection(BaseCollection):
@@ -322,9 +314,18 @@ class TrackingCollection(BaseCollection):
         ```
 
         Handles default to the file stem (e.g. ``mouse1``, ``mouse2`` above) plus
-        the group name. If two files in the same group share a stem, parent
-        directory names are prepended (only as far as needed) to keep handles
-        unique:
+        the group name (here ``mouse1``, ``mouse2``, with no group suffix, since
+        those names are unique across the whole input):
+
+        ```pycon
+        >>> sorted(tc.keys())
+        ['mouse1', 'mouse2']
+
+        ```
+
+        If two files anywhere in the input share a stem, parent directory names
+        are prepended (only as far as needed) to keep handles unique -- the group
+        name is not involved unless that's not enough to disambiguate:
 
         ```pycon
         >>> import tempfile, shutil
@@ -337,10 +338,27 @@ class TrackingCollection(BaseCollection):
         ...         cohort_a.mkdir(); cohort_b.mkdir()
         ...         a = cohort_a / '1.csv'; b = cohort_b / '1.csv'
         ...         _ = shutil.copy(p, a); _ = shutil.copy(p, b)
-        ...     groups = {'control': [a, b]}
+        ...     groups = {'control': [a], 'treated': [b]}
         ...     tc = TrackingCollection.from_groups(groups, fps=30)
         >>> sorted(tc.keys())
-        ['cohortA_1_control', 'cohortB_1_control']
+        ['cohortA_1', 'cohortB_1']
+
+        ```
+
+        If the *same* file is deliberately included in more than one group, the
+        path-based disambiguation can't tell the copies apart, so the group name
+        is appended instead:
+
+        ```pycon
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     d = Path(d)
+        ...     with data_path('py3r.behaviour.tracking._data', 'yolo3r.csv') as p:
+        ...         a = d / 'mouse1.csv'
+        ...         _ = shutil.copy(p, a)
+        ...     groups = {'control': [a], 'treated': [a]}
+        ...     tc = TrackingCollection.from_groups(groups, fps=30)
+        >>> sorted(tc.keys())
+        ['mouse1_control', 'mouse1_treated']
 
         ```
         """
@@ -368,12 +386,33 @@ class TrackingCollection(BaseCollection):
                 )
             safe_names[group_name] = safe
 
+        # Disambiguate handles globally, across all groups, so that handles stay
+        # plain filenames whenever possible. A group suffix (or, failing that, a
+        # numeric index) is only added where a label would otherwise still collide
+        # -- e.g. the same file deliberately included in more than one group.
+        all_paths = [p for paths in groups.values() for p in paths]
+        all_group_names = [g for g, paths in groups.items() for _ in paths]
+        labels = _disambiguate_stems(all_paths)
+
+        label_counts = Counter(labels)
+        for i, group_name in enumerate(all_group_names):
+            if label_counts[labels[i]] > 1:
+                labels[i] = f"{labels[i]}_{safe_names[group_name]}"
+
+        final_counts = Counter(labels)
+        seen: dict[str, int] = {}
+        for i, label in enumerate(labels):
+            if final_counts[label] > 1:
+                seen[label] = seen.get(label, 0) + 1
+                labels[i] = f"{label}_{seen[label]}"
+
         per_group: list[TrackingCollection] = []
+        idx = 0
         for group_name, paths in groups.items():
-            safe = safe_names[group_name]
-            stems = _disambiguate_stems(paths)
+            group_labels = labels[idx : idx + len(paths)]
+            idx += len(paths)
             handles_and_paths = {
-                f"{stem}_{safe}": str(p) for stem, p in zip(stems, paths, strict=True)
+                label: str(p) for label, p in zip(group_labels, paths, strict=True)
             }
             if fmt == "yolo3r":
                 tc = cls.from_yolo3r(handles_and_paths, fps=fps)


### PR DESCRIPTION
### Summary
<!-- 
A short description of what this PR does.

Example:
- Adds aggregation functions for multi-animal keypoint trajectories.
-->
- improved disambiguation in `TrackingCollection.from_groups()`
- bugfix for path-like handles being read as paths across the repo
- new helper to collate summary dfs for bin analysis

### Type of change
<!-- 
At least one MUST be checked.
Use lowercase x exactly like this: [x]
-->
- [x] ✨ Feature
- [x] 🐛 Bug fix
- [ ] 💥 Breaking change
- [ ] 🧹 Chore / Refactor
- [ ] 📚 Docs

### User-facing change
<!-- 
This is what will appear in the release notes.
Write as a single bullet starting with - 

Example:
- Fixed incorrect body-angle computation when animals rotate >180°.
-->
- new helper to collate summary dfs across bins

### Testing
<!-- 
Explain how you tested the change.

Example:
- Added docstring tests covering interpolation of missing keypoints.
-->
- docstring, manual
